### PR TITLE
Initial spike to scope imported scss files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,37 @@
 /* jshint node: true */
 'use strict';
 
+var buildMap = require('./lib/build-imports-map');
+var scope = require('./lib/broccoli-scope-scss-imports');
+var addMap = require('./lib/broccoli-add-imports-map');
+var mergeTrees = require('broccoli-merge-trees');
+
 module.exports = {
   name: 'untitled-ui',
-  
+
+  setupPreprocessorRegistry: function(type, registry) {
+    if (type !== 'self') { return; }
+
+    var map = buildMap(registry.app.project.root, {
+      include: ['components/**/*.scss']
+    });
+
+    registry.add('css', {
+      name: 'scope-scss-imports',
+      toTree: function(tree) {
+        return scope(tree, { map: map });
+      }
+    });
+
+    registry.add('js', {
+      name: 'add-imports-map',
+      toTree: function(tree) {
+        var mapTree = addMap(tree, { map: map });
+        return mergeTrees([tree, mapTree]);
+      }
+    })
+  },
+
   included: function(app) {
     this._super.included(app);
 

--- a/lib/broccoli-add-imports-map.js
+++ b/lib/broccoli-add-imports-map.js
@@ -1,0 +1,31 @@
+/* jshint node: true */
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var mkdirp = require('mkdirp');
+var CachingWriter = require('broccoli-caching-writer');
+
+BroccoliAddImportsMap.prototype = Object.create(CachingWriter.prototype);
+BroccoliAddImportsMap.prototype.constructor = BroccoliAddImportsMap;
+
+function BroccoliAddImportsMap(inputNode, options) {
+  if (!(this instanceof BroccoliAddImportsMap)) {
+    return new BroccoliAddImportsMap(inputNode, options);
+  }
+
+  CachingWriter.call(this, [inputNode]);
+
+  this.map = options.map || {};
+}
+
+BroccoliAddImportsMap.prototype.build = function() {
+  var outputPath = path.join(this.outputPath, 'modules/untitled-ui');
+  var filePath = path.join(outputPath, 'imports-map.js');
+  var mapString = JSON.stringify(this.map);
+
+  mkdirp.sync(outputPath);
+  fs.writeFileSync(filePath, 'export default ' + mapString, 'utf8');
+};
+
+module.exports = BroccoliAddImportsMap;

--- a/lib/broccoli-scope-scss-imports.js
+++ b/lib/broccoli-scope-scss-imports.js
@@ -1,0 +1,65 @@
+/* jslint node: true */
+'use strict';
+
+var Filter = require('broccoli-persistent-filter');
+var parser = require('scss-parser');
+
+BroccoliScopeScssImports.prototype = Object.create(Filter.prototype);
+BroccoliScopeScssImports.prototype.constructor = BroccoliScopeScssImports;
+
+function BroccoliScopeScssImports(inputNode, options) {
+  if (!(this instanceof BroccoliScopeScssImports)) {
+    return new BroccoliScopeScssImports(inputNode, options);
+  }
+
+  Filter.call(this, inputNode);
+
+  this.map = options.map;
+}
+
+BroccoliScopeScssImports.prototype.extensions = ['scss'];
+BroccoliScopeScssImports.prototype.targetExtension = 'scss';
+
+BroccoliScopeScssImports.prototype.processString = function(content, relPath) {
+  var prefix = this.map && this.map[relPath];
+
+  return prefix ? processScss(content, prefix) : content;
+};
+
+var processScss = function(content, prefix) {
+  var ast = parser.parse(content);
+
+  // method 1
+  // var createQueryWrapper = require('query-ast');
+  // var $ = createQueryWrapper(ast);
+  // $('class').nodes.forEach(function(nodeWrapper) {
+  //   nodeWrapper.node.value.forEach(function(value) {
+  //     value = prefix + value;
+  //   });
+  // });
+  // var scss = parser.stringify($().get(0));
+
+  // method 2
+  // walkClasses(ast, function(node) {
+  //   node.value[0].value = prefix + node.value[0].value;
+  // });
+
+  var scss = parser.stringify(ast);
+  return scss;
+};
+
+var walkClasses = function(node, callback) {
+  var util = require('util');
+
+  if (node.type === 'class') {
+    callback(node);
+  }
+
+  if (util.isArray(node.value)) {
+    node.value.forEach(function(childNode) {
+      walkClasses(childNode, callback);
+    });
+  }
+}
+
+module.exports = BroccoliScopeScssImports;

--- a/lib/build-imports-map.js
+++ b/lib/build-imports-map.js
@@ -1,0 +1,76 @@
+/* jshint node:true */
+'use strict';
+
+// TODO have this build the map based on the scss import
+// dependency map instead of the styles directory structure
+
+var path = require('path');
+var walkSync = require('walk-sync');
+
+module.exports = function(projectRoot, options) {
+  options = options || {};
+
+  var scssRoot = path.join(projectRoot, 'addon/styles');
+  var include = options.include || ['**/*.scss'];
+  var ignored = options.ignore  || [];
+
+  var files = workingFiles(scssRoot, include, ignored);
+
+  return buildMap(files, options.debug);
+};
+
+var workingFiles = function(scssRoot, include, ignored) {
+  var includeFiles = walkSync(scssRoot, { globs: include });
+  var ignoredFiles = walkSync(scssRoot, { globs: ignored });
+
+  return includeFiles.filter(function(file) {
+    return ignoredFiles.indexOf(file) === -1;
+  });
+};
+
+var buildMap = function(files, debug) {
+  return files.reduce(function(manifest, file) {
+    var key = file;
+    var prefix;
+
+    if (debug) {
+      prefix = key.replace('.css', '').replace(/\//g, '-');
+    } else {
+      prefix = generateUniquePrefix(manifest);
+    }
+
+    manifest[key] = prefix;
+
+    return manifest;
+  }, {});
+};
+
+var generateUniquePrefix = function(manifest, isCopy, prevClass) {
+  var mut, next, currentKey, currentClass;
+  var prefix = '_u';
+
+  if (isCopy) {
+    mut = manifest;
+  } else {
+    mut = JSON.parse(JSON.stringify(manifest));
+  }
+
+  // null case
+  if (Object.keys(mut).length === 0 && !prevClass) {
+    return prefix + '0';
+  }
+
+  // base case
+  if (Object.keys(mut).length === 0 && prevClass) {
+    next = Number(prevClass.slice(prefix.length)) + 1;
+
+    return prefix + next;
+  }
+
+  // recurse
+  currentKey = Object.keys(mut)[0];
+  currentClass = mut[currentKey];
+  delete mut[currentKey];
+
+  return generateUniquePrefix(mut, true, currentClass);
+};

--- a/package.json
+++ b/package.json
@@ -52,9 +52,16 @@
     "ember-addon"
   ],
   "dependencies": {
+    "broccoli-caching-writer": "^2.2.1",
+    "broccoli-merge-trees": "^1.1.1",
+    "broccoli-persistent-filter": "^1.2.0",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.5",
-    "ember-cli-sass": "5.3.1"
+    "ember-cli-sass": "5.3.1",
+    "mkdirp": "^0.5.1",
+    "query-ast": "^1.0.0",
+    "scss-parser": "^1.0.0",
+    "walk-sync": "^0.2.6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
- [x] build hash of imported files scoped mapped to uniq class prefixes
- [x] add the map of prefixes to the js output
- [ ] use map of prefixes to transform the scss files before ember-cli-sass gets ahold of the files
