### PR TITLE
Button theme experiment

### DIFF
--- a/addon/components/ui-button--default.js
+++ b/addon/components/ui-button--default.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+import layout from 'untitled-ui/templates/components/ui-button--default';
+
+export default Ember.Component.extend({
+  layout,
+
+  tagName: '',
+  baseClass: 'ui-button-default'
+});

--- a/addon/components/ui-button--primary.js
+++ b/addon/components/ui-button--primary.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+import layout from 'untitled-ui/templates/components/ui-button--default';
+
+export default Ember.Component.extend({
+  layout,
+
+  tagName: '',
+  baseClass: 'ui-button-primary'
+});

--- a/addon/components/ui-button.js
+++ b/addon/components/ui-button.js
@@ -5,16 +5,15 @@ export default Ember.Component.extend({
   layout,
 
   tagName: '',
-  kind: 'default',
   size: 'medium',
   disabled: false,
   loading: false,
 
   isDisabled: Ember.computed.or('disabled', 'loading'),
 
-  classes: Ember.computed('size', 'kind', 'loading', function() {
+  classes: Ember.computed('size', 'loading', function() {
     let classes = [
-      'ui-button', `ui-button--${this.get('kind')}`,
+      'ui-button',
       `ui-fontSize--${this.get('size')}`
     ];
 

--- a/addon/components/ui-button.js
+++ b/addon/components/ui-button.js
@@ -9,23 +9,12 @@ export default Ember.Component.extend({
   disabled: false,
   loading: false,
 
+  frame: "ui-button--default",
+
   isDisabled: Ember.computed.or('disabled', 'loading'),
 
-  classes: Ember.computed('size', 'loading', function() {
-    let classes = [
-      'ui-button',
-      `ui-fontSize--${this.get('size')}`
-    ];
-
-    if (this.get('isDisabled')) {
-      classes.push('ui-button--disabled');
-    }
-
-    if (this.get('loading')) {
-      classes.push('ui-button--loading');
-    }
-
-    return classes.join(' ');
+  sizeClass: Ember.computed('size', function() {
+    return `ui-fontSize--${this.get('size')}`;
   }),
 
   actions: {

--- a/addon/styles/components/ui-button.scss
+++ b/addon/styles/components/ui-button.scss
@@ -31,7 +31,7 @@ TODOs:
 
 
 /* Default Style */
-.ui-button {
+.ui-button-default {
   &__button {
     border-radius: $untitled-ui--border-radius;
     cursor: pointer;
@@ -56,64 +56,149 @@ TODOs:
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+}
 
-  &:active {
-    .ui-button__button {
-      background: linear-gradient(to top, lighten($untitled-ui--button-default-border-color, 15%) 0%, $untitled-ui--button-default-border-color 100%);
-    }
-
-    .ui-button__label {
-      transform: translateY(1px);
-    }
-
-    .ui-button__wrapper {
-      background: #f9f9f9;
-    }
+.ui-button:active {
+  .ui-button-default__button {
+    background: linear-gradient(to top, lighten($untitled-ui--button-default-border-color, 15%) 0%, $untitled-ui--button-default-border-color 100%);
   }
 
-  &:focus {
-    .ui-button__button {
-      box-shadow: 0px 0px 4px #0090ff;
-      background: rgba(0, 107, 255, 0.5); /* make the border part of the shadow */
-    }
+  .ui-button-default__label {
+    transform: translateY(1px);
   }
 
-  &--disabled {
-    .ui-button__button {
-      pointer-events: none;
-      background: linear-gradient(to bottom, lighten($untitled-ui--button-default-border-color, 15%) 0%, $untitled-ui--button-default-border-color 100%);
-      color: #ababab;
-    }
-    
-    .ui-button__wrapper {
-      background: #f9f9f9;
-    }
+  .ui-button-default__wrapper {
+    background: #f9f9f9;
+  }
+}
+
+.ui-button:focus {
+  .ui-button-default__button {
+    box-shadow: 0px 0px 4px #0090ff;
+    background: rgba(0, 107, 255, 0.5); /* make the border part of the shadow */
+  }
+}
+
+.ui-button-default--disabled {
+  pointer-events: none;
+  background: linear-gradient(to bottom, lighten($untitled-ui--button-default-border-color, 15%) 0%, $untitled-ui--button-default-border-color 100%);
+  color: #ababab;
+
+  .ui-button-default__wrapper {
+    background: #f9f9f9;
+  }
+}
+
+.ui-button-default--loading {
+  /*
+    TODO Placeholder until we can replace with proper spinner
+    Copied from http://www.designcouch.com/home/why/2013/05/23/dead-simple-pure-css-loading-spinner
+  */
+  &:before {
+    content: "";
+    display: block;
+    position: absolute;
+    top: calc(50% - 12px);
+    left: calc(50% - 12px);
+    height: 15px;
+    width: 15px;
+    animation: ui-button--loading--rotation .6s infinite linear;
+    border-left: 4px solid rgba(0, 174, 239, .15);
+    border-right: 4px solid rgba(0, 174, 239, .15);
+    border-bottom: 4px solid rgba(0, 174, 239, .15);
+    border-top: 4px solid rgba(0, 174, 239, .8);
+    border-radius: 100%;
   }
 
-  &--loading {
-    /*
-      TODO Placeholder until we can replace with proper spinner
-      Copied from http://www.designcouch.com/home/why/2013/05/23/dead-simple-pure-css-loading-spinner
-    */
-    &:before {
-      content: "";
-      display: block;
-      position: absolute;
-      top: calc(50% - 12px);
-      left: calc(50% - 12px);
-      height: 15px;
-      width: 15px;
-      animation: ui-button--loading--rotation .6s infinite linear;
-      border-left: 4px solid rgba(0, 174, 239, .15);
-      border-right: 4px solid rgba(0, 174, 239, .15);
-      border-bottom: 4px solid rgba(0, 174, 239, .15);
-      border-top: 4px solid rgba(0, 174, 239, .8);
-      border-radius: 100%;
-    }
+  .ui-button-default__label {
+    opacity: 0;
+  }
+}
 
-    .ui-button__label {
-      opacity: 0;
-    }
+
+/* Primary Style */
+/* TODO: Should be possible to inherited from default style */
+.ui-button-primary {
+  &__button {
+    border-radius: $untitled-ui--border-radius;
+    cursor: pointer;
+    padding: 1px;
+    line-height: 2.3em;
+    box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.1);
+    background: linear-gradient(to bottom, lighten($untitled-ui--button-primary-border-color, 15%) 0%, $untitled-ui--button-primary-border-color 100%);
+    color: $untitled-ui--button-primary-label-color;
+  }
+
+  &__wrapper {
+    border-radius: inherit;
+    background: white;
+  }
+
+  &__label {
+    padding: 0 0.9em;
+    min-height: 10px;
+    font-style: normal;
+    position: relative;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.ui-button:active {
+  .ui-button-primary__button {
+    background: linear-gradient(to top, lighten($untitled-ui--button-primary-border-color, 15%) 0%, $untitled-ui--button-primary-border-color 100%);
+  }
+
+  .ui-button-primary__label {
+    transform: translateY(1px);
+  }
+
+  .ui-button-primary__wrapper {
+    background: #f9f9f9;
+  }
+}
+
+.ui-button:focus {
+  .ui-button-primary__button {
+    box-shadow: 0px 0px 4px #0090ff;
+    background: rgba(0, 107, 255, 0.5); /* make the border part of the shadow */
+  }
+}
+
+.ui-button-primary--disabled {
+  pointer-events: none;
+  background: linear-gradient(to bottom, lighten($untitled-ui--button-default-border-color, 15%) 0%, $untitled-ui--button-default-border-color 100%);
+  color: #ababab;
+
+  .ui-button-default__wrapper {
+    background: #f9f9f9;
+  }
+}
+
+.ui-button-primary--loading {
+  /*
+    TODO Placeholder until we can replace with proper spinner
+    Copied from http://www.designcouch.com/home/why/2013/05/23/dead-simple-pure-css-loading-spinner
+  */
+  &:before {
+    content: "";
+    display: block;
+    position: absolute;
+    top: calc(50% - 12px);
+    left: calc(50% - 12px);
+    height: 15px;
+    width: 15px;
+    animation: ui-button--loading--rotation .6s infinite linear;
+    border-left: 4px solid rgba(0, 174, 239, .15);
+    border-right: 4px solid rgba(0, 174, 239, .15);
+    border-bottom: 4px solid rgba(0, 174, 239, .15);
+    border-top: 4px solid rgba(0, 174, 239, .8);
+    border-radius: 100%;
+  }
+
+  .ui-button-default__label {
+    opacity: 0;
   }
 }
 

--- a/addon/styles/components/ui-button.scss
+++ b/addon/styles/components/ui-button.scss
@@ -5,14 +5,11 @@ TODOs:
 
 */
 
-%ui-button {
+.ui-button {
+  padding: 0;
+  background: transparent;
   border: none;
-  border-radius: $untitled-ui--border-radius;
-  cursor: pointer;
-  padding: 1px;
   outline: none;
-  line-height: 2.3em;
-  box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.1);
   vertical-align: middle;
   position: relative;
   user-select: none;
@@ -26,54 +23,68 @@ TODOs:
   &:-moz-focusring {
     outline: none;
   }
-}
 
-%ui-button--active {
-  box-shadow: none;
-
-  /* TODO: Scope labels to button instance only */
-  .ui-button__label {
-    transform: translateY(1px);
-  }
-
-  .ui-button__wrapper {
-    background: #f9f9f9;
+  &:active {
+    box-shadow: none;
   }
 }
 
+
+/* Default Style */
 .ui-button {
-  &--default {
-    @extend %ui-button;
+  &__button {
+    border-radius: $untitled-ui--border-radius;
+    cursor: pointer;
+    padding: 1px;
+    line-height: 2.3em;
+    box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.1);
     background: linear-gradient(to bottom, lighten($untitled-ui--button-default-border-color, 15%) 0%, $untitled-ui--button-default-border-color 100%);
     color: $untitled-ui--button-default-label-color;
-
-    &:active {
-      @extend %ui-button--active;
-      background: linear-gradient(to top, lighten($untitled-ui--button-default-border-color, 15%) 0%, $untitled-ui--button-default-border-color 100%);
-    }
   }
 
-  &--primary {
-    @extend %ui-button;
-    background: linear-gradient(to bottom, lighten($untitled-ui--button-primary-border-color, 15%) 0%, $untitled-ui--button-primary-border-color 100%);
-    color: $untitled-ui--button-primary-label-color;
+  &__wrapper {
+    border-radius: inherit;
+    background: white;
+  }
 
-    &:active {
-      @extend %ui-button--active;
-      background: linear-gradient(to top, lighten($untitled-ui--button-primary-border-color, 15%) 0%, $untitled-ui--button-primary-border-color 100%);
+  &__label {
+    padding: 0 0.9em;
+    min-height: 10px;
+    font-style: normal;
+    position: relative;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &:active {
+    .ui-button__button {
+      background: linear-gradient(to top, lighten($untitled-ui--button-default-border-color, 15%) 0%, $untitled-ui--button-default-border-color 100%);
+    }
+
+    .ui-button__label {
+      transform: translateY(1px);
+    }
+
+    .ui-button__wrapper {
+      background: #f9f9f9;
     }
   }
 
   &:focus {
-    box-shadow: 0px 0px 4px #0090ff;
-    background: rgba(0, 107, 255, 0.5); /* make the border part of the shadow */
+    .ui-button__button {
+      box-shadow: 0px 0px 4px #0090ff;
+      background: rgba(0, 107, 255, 0.5); /* make the border part of the shadow */
+    }
   }
 
   &--disabled {
-    pointer-events: none;
-    background: linear-gradient(to bottom, lighten($untitled-ui--button-default-border-color, 15%) 0%, $untitled-ui--button-default-border-color 100%);
-    color: #ababab;
-
+    .ui-button__button {
+      pointer-events: none;
+      background: linear-gradient(to bottom, lighten($untitled-ui--button-default-border-color, 15%) 0%, $untitled-ui--button-default-border-color 100%);
+      color: #ababab;
+    }
+    
     .ui-button__wrapper {
       background: #f9f9f9;
     }
@@ -103,21 +114,6 @@ TODOs:
     .ui-button__label {
       opacity: 0;
     }
-  }
-
-  &__wrapper {
-    background: white;
-    border-radius: inherit;
-  }
-
-  &__label {
-    padding: 0 0.9em;
-    min-height: 10px;
-    font-style: normal;
-    position: relative;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 }
 

--- a/addon/templates/components/ui-button--default.hbs
+++ b/addon/templates/components/ui-button--default.hbs
@@ -1,0 +1,9 @@
+<div class="{{baseClass}}__button
+            {{if disabled (concat baseClass '--disabled')}}
+            {{if loading (concat baseClass '--loading')}}">
+  <div class="{{baseClass}}__wrapper">
+    <div class="{{baseClass}}__label">
+      {{yield}}
+    </div>
+  </div>
+</div>

--- a/addon/templates/components/ui-button.hbs
+++ b/addon/templates/components/ui-button.hbs
@@ -1,7 +1,9 @@
 <button class={{classes}} disabled={{isDisabled}} {{action "onclick"}}>
-  <div class="ui-button__wrapper">
-    <div class="ui-button__label">
-      {{yield}}
+  <div class="ui-button__button">
+    <div class="ui-button__wrapper">
+      <div class="ui-button__label">
+        {{yield}}
+      </div>
     </div>
   </div>
 </button>

--- a/addon/templates/components/ui-button.hbs
+++ b/addon/templates/components/ui-button.hbs
@@ -1,9 +1,8 @@
-<button class={{classes}} disabled={{isDisabled}} {{action "onclick"}}>
-  <div class="ui-button__button">
-    <div class="ui-button__wrapper">
-      <div class="ui-button__label">
-        {{yield}}
-      </div>
-    </div>
-  </div>
+<button class="ui-button {{sizeClass}}" disabled={{isDisabled}} {{action "onclick"}}>
+  {{#component frame
+    disabled=isDisabled
+    loading=loading
+    size=size}}
+      {{yield}}
+  {{/component}}
 </button>

--- a/app/components/ui-button--default.js
+++ b/app/components/ui-button--default.js
@@ -1,0 +1,1 @@
+export { default } from 'untitled-ui/components/ui-button--default';

--- a/app/components/ui-button--primary.js
+++ b/app/components/ui-button--primary.js
@@ -1,0 +1,1 @@
+export { default } from 'untitled-ui/components/ui-button--primary';

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -98,19 +98,19 @@
   {{#panel.content}}
     <h2>Sizes</h2>
 
-    {{#ui-button kind="default" size="x-small"}}
+    {{#ui-button size="x-small"}}
       X-Small
     {{/ui-button}}
 
-    {{#ui-button kind="primary" size="x-small"}}
+    {{#ui-button frame=(component "ui-button--primary") size="x-small"}}
       X-Small
     {{/ui-button}}
 
-    {{#ui-button kind="default" size="small"}}
+    {{#ui-button size="small"}}
       Small
     {{/ui-button}}
 
-    {{#ui-button kind="primary" size="small"}}
+    {{#ui-button frame=(component "ui-button--primary") size="small"}}
       Small
     {{/ui-button}}
 
@@ -118,23 +118,23 @@
       Medium
     {{/ui-button}}
 
-    {{#ui-button kind="primary"}}
+    {{#ui-button frame=(component "ui-button--primary")}}
       Medium
     {{/ui-button}}
 
-    {{#ui-button kind="default" size="large"}}
+    {{#ui-button size="large"}}
       Large
     {{/ui-button}}
 
-    {{#ui-button kind="primary" size="large"}}
+    {{#ui-button frame=(component "ui-button--primary") size="large"}}
       Large
     {{/ui-button}}
 
-    {{#ui-button kind="default" size="x-large"}}
+    {{#ui-button size="x-large"}}
       X-Large
     {{/ui-button}}
 
-    {{#ui-button kind="primary" size="x-large"}}
+    {{#ui-button frame=(component "ui-button--primary")size="x-large"}}
       X-Large
     {{/ui-button}}
 
@@ -144,7 +144,7 @@
       hello world
     {{/ui-button}}
 
-    {{#ui-button kind="primary" disabled=true}}
+    {{#ui-button frame=(component "ui-button--primary") disabled=true}}
       hello world
     {{/ui-button}}
 


### PR DESCRIPTION
This separates function and aesthetic for the button component. The functionality is all contained in the `ui-button` component so the frame is only concerned with how it looks.

The css is still copy and paste to create a new style and needs to be improved.

To swap out a button's frame you go:

`{{#ui-button frame=(component "ui-button--primary") size="small"}}
  Button Label
{{/ui-button}}`

and pass in any component you want to use as the aesthetic. Not sure what the naming convention should be for these aesthetic components.
