### PR TITLE
Autoprefix component name to all component class templates

### DIFF
--- a/addon/helpers/-ui-component-class.js
+++ b/addon/helpers/-ui-component-class.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+
+export default Ember.Helper.helper(function ([prefix, ...classNames]) {
+  var classString = '';
+
+  classNames.forEach(function(name) {
+    if (!name) return;
+
+    var trimmedName = name.replace(/\s/g, '');
+    if (trimmedName === '') return;
+
+    if (trimmedName === ':component') {
+      classString += `${prefix} `;
+    } else {
+      classString += `${prefix}${trimmedName} `;
+    }
+  });
+
+  return classString;
+});

--- a/addon/templates/components/ui-button--default.hbs
+++ b/addon/templates/components/ui-button--default.hbs
@@ -4,19 +4,19 @@
   class="{{classes.parent}}
          {{classes.size}}
          {{classes.class}}
-         ui-button--default
-         {{if states.active 'ui-button--default--active'}}
-         {{if states.focus 'ui-button--default--focus'}}
-         {{if states.disabled 'ui-button--default--disabled'}}
-         {{if states.loading 'ui-button--default--loading'}}
-         {{if group 'ui-button--default--group-button'}}
-         {{if group.isFirstChild 'ui-button--default--first-child'}}
-         {{if group.isLastChild 'ui-button--default--last-child'}}">
-  <div class="ui-button--default__wrapper
-             {{if states.active 'ui-button--default__wrapper--active'}}">
-    <div class="ui-button--default__label
-               {{if states.loading 'ui-button--default__label--loading'}}
-               {{if states.active 'ui-button--default__label--active'}}">
+         :component
+         {{if states.active '--active'}}
+         {{if states.focus '--focus'}}
+         {{if states.disabled '--disabled'}}
+         {{if states.loading '--loading'}}
+         {{if group '--group-button'}}
+         {{if group.isFirstChild '--first-child'}}
+         {{if group.isLastChild '--last-child'}}">
+  <div class="__wrapper
+             {{if states.active '__wrapper--active'}}">
+    <div class="__label
+               {{if states.loading '__label--loading'}}
+               {{if states.active '__label--active'}}">
       {{yield}}
     </div>
   </div>

--- a/app/helpers/-ui-component-class.js
+++ b/app/helpers/-ui-component-class.js
@@ -1,0 +1,1 @@
+export { default, uiComponentClass } from 'untitled-ui/helpers/-ui-component-class';

--- a/index.js
+++ b/index.js
@@ -1,12 +1,23 @@
 /* jshint node: true */
 'use strict';
 
+var TransformComponentClasses = require('./lib/transform-component-classes');
+
 module.exports = {
   name: 'untitled-ui',
-  
+
   included: function(app) {
     this._super.included(app);
 
     app.import('vendor/normalize.css');
+  },
+
+  setupPreprocessorRegistry: function(type, registry) {
+    if (type !== 'self') return;
+
+    registry.add('htmlbars-ast-plugin', {
+      name: 'transform-component-classes',
+      plugin: TransformComponentClasses
+    });
   }
 };

--- a/lib/transform-component-classes.js
+++ b/lib/transform-component-classes.js
@@ -1,0 +1,121 @@
+var COMPONENT_MODULE_PATTERN = /.+\/components\/.+/;
+var COMPONENT_NAME_PATTERN = /.+\/components\/(.+)\.hbs/;
+
+function TransformComponentClasses(options) {
+  this.syntax = null;
+  this.options = options;
+}
+
+TransformComponentClasses.prototype = {
+  transform: function (ast) {
+    var moduleName = this.options && this.options.moduleName;
+    if (this.isComponentTemplate(moduleName)) {
+      return this.transformComponentTemplate(ast);
+    }
+    return ast;
+  },
+
+  isComponentTemplate: function (moduleName) {
+    return COMPONENT_MODULE_PATTERN.test(moduleName);
+  },
+
+  transformComponentTemplate: function (ast) {
+    var walker = new this.syntax.Walker();
+    var _this = this;
+    walker.visit(ast, function(node) {
+      if (node.type === 'ElementNode') {
+        _this.transformElementNode(node);
+      }
+    });
+    return ast;
+  },
+
+  transformElementNode: function (elementNode) {
+    var attributes = elementNode.attributes;
+
+    for (var i=0; i<attributes.length; i++) {
+      var attrNode = attributes[i];
+      if (attrNode.name === 'class') {
+        this.transformClassAttr(attrNode);
+      }
+    }
+  },
+
+  transformClassAttr: function (classAttrNode) {
+    var value = classAttrNode.value;
+    var componentName = this.options.moduleName.match(COMPONENT_NAME_PATTERN)[1];
+    var params;
+    switch (value.type) {
+      case 'TextNode': // class="foo bar"
+        params = paramsFromTextNode(value, componentName);
+        break;
+      case 'ConcatStatement': // class="foo {{bar}}"
+        params = paramsFromConcatStatement(value, componentName);
+        break;
+      case 'MustacheStatement': // class={{foo}}
+        params = paramsFromMustacheStatement(value, componentName);
+        break;
+      default:
+        throw new Error('unrecognized node type "' + value.type + '" for class attribute value');
+    }
+
+    classAttrNode.value = {
+      type: 'MustacheStatement',
+      path: {
+        type: 'PathExpression',
+        original: '-ui-component-class',
+        parts: [ '-ui-component-class' ]
+      },
+      params: params,
+      hash: { type: 'Hash', pairs: [] },
+      escaped: true
+    };
+  }
+};
+
+function makeMustacheAnExpression(mustacheStatement) {
+  if (mustacheStatement.params.length ||
+      mustacheStatement.hash.pairs.length ||
+      mustacheStatement.path.original.indexOf('-') !== -1) {
+    mustacheStatement.type = 'SubExpression';
+    return mustacheStatement;
+  }
+  return mustacheStatement.path;
+}
+
+function paramsFromTextNode(textNode, componentName) {
+  return [{
+    type: 'StringLiteral',
+    original: componentName,
+    value: componentName
+  }, {
+    type: "StringLiteral",
+    value: textNode.chars,
+    original: textNode.chars
+  }];
+}
+
+function paramsFromConcatStatement(concatStatement, componentName) {
+  var params = concatStatement.parts;
+  return [{
+    type: 'StringLiteral',
+    original: componentName,
+    value: componentName
+  }].concat(concatStatement.parts.map(function (node) {
+    if (node.type === 'MustacheStatement') {
+      return makeMustacheAnExpression(node);
+    }
+    return node;
+  }));
+}
+
+function paramsFromMustacheStatement(mustacheStatement, componentName) {
+  mustacheStatement.type = 'SubExpression';
+  return [{
+    type: 'StringLiteral',
+    original: componentName,
+    value: componentName
+  }, makeMustacheAnExpression(mustacheStatement)];
+}
+
+module.exports = TransformComponentClasses;

--- a/tests/unit/helpers/-ui-component-class-test.js
+++ b/tests/unit/helpers/-ui-component-class-test.js
@@ -1,0 +1,10 @@
+import { uiComponentClass } from 'dummy/helpers/-ui-component-class';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | ui component class');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = uiComponentClass([42]);
+  assert.ok(result);
+});


### PR DESCRIPTION
- implements an htmlbars-ast-plugin for the addon's components
- transforms all component class attrs to use the -ui-component-class helper
- helper prefixes the component name to each class
