### PR TITLE
Normalize class names before prefixing

### DIFF
--- a/addon/helpers/-ui-component-class.js
+++ b/addon/helpers/-ui-component-class.js
@@ -3,19 +3,24 @@ import Ember from 'ember';
 const FONT_SIZE_PATTERN = /font-size/;
 
 export default Ember.Helper.helper(function ([prefix, ...classNames]) {
-  return classNames.reduce(function(string, name) {
-    if (!name) return string;
+  let normalizedClassNames = classNames.reduce(function(names, name) {
+    name.split(/\s/).forEach(function(part) {
+      if (part && part !== '') {
+        names.push(part);
+      }
+    });
 
-    let trimmedName = name.replace(/\s/g, '');
-    if (trimmedName === '') return string;
+    return names;
+  }, []);
 
+  return normalizedClassNames.reduce(function(string, name) {
     switch (true) {
-      case (trimmedName === ':component'):
+      case (name === ':component'):
         return string += `${prefix} `;
-      case (FONT_SIZE_PATTERN.test(trimmedName)):
-        return string += `${trimmedName} `;
+      case (FONT_SIZE_PATTERN.test(name)):
+        return string += `${name} `;
       default:
-        return string += `${prefix}${trimmedName} `;
+        return string += `${prefix}${name} `;
     }
   }, '');
 });


### PR DESCRIPTION
As a note need to start adding tests for handling the classNames param in this helper. Need to test something like:

```
[undefined, null, '\n      \n', '\n     foo     bar      \n', 'bar baz', 'foo']
```
