### PR TITLE
Remove extra wrapper div for ui-panel

### DIFF
--- a/addon/components/ui-panel.js
+++ b/addon/components/ui-panel.js
@@ -8,11 +8,13 @@ export default Ember.Component.extend({
   kind: 'default',
   size: 'medium',
 
-  sizeClass: Ember.computed('size', function() {
-    return `ui-font-size--${this.get('size')}`;
+  classes: Ember.computed('size', function() {
+    return {
+      size: `ui-font-size--${this.get('size')}`
+    };
   }),
 
   frame: Ember.computed('kind', function() {
     return `ui-panel--${this.get('kind')}`;
-  }),
+  })
 });

--- a/addon/styles/components/ui-panel.scss
+++ b/addon/styles/components/ui-panel.scss
@@ -1,3 +1,0 @@
-@component() {
-  max-height: inherit;
-}

--- a/addon/templates/components/ui-panel--default.hbs
+++ b/addon/templates/components/ui-panel--default.hbs
@@ -1,4 +1,4 @@
-<div class=":component">
+<div class=":component {{classes.size}}">
   <div class="wrapper">
     {{yield (hash
       titlebar=(component "ui-panel--default-titlebar")

--- a/addon/templates/components/ui-panel.hbs
+++ b/addon/templates/components/ui-panel.hbs
@@ -1,7 +1,6 @@
-<div class=":component {{sizeClass}}">
-  {{#component frame
-    kind=kind
-    size=size as |component|}}
-      {{yield component}}
-  {{/component}}
-</div>
+{{#component frame
+  classes=classes
+  kind=kind
+  size=size as |component|}}
+    {{yield component}}
+{{/component}}


### PR DESCRIPTION
- Removes the div that currently wraps the ui-panel frame component.
- Removes the `ui-panel` mixin, since the div it would be
  applied to no longer exists.
- Moves the rest of the classes that were being applied to the wrapping
  component, such as size, onto the frame component.

From:

``` html
<div class="ui-panel ui-font-size--medium">
  <div class="ui-panel--default"></div>
</div>
```

To:

``` html
<div class="ui-panel--default ui-font-size--medium"></div>
```
