### PR TITLE
Add blueprints for generating ui-components and ui-component-kinds

### DIFF
--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/ui-component-addon/files/__root__/__path__/__name__.js
+++ b/blueprints/ui-component-addon/files/__root__/__path__/__name__.js
@@ -1,0 +1,1 @@
+export { default } from '<%= modulePath %>';

--- a/blueprints/ui-component-addon/index.js
+++ b/blueprints/ui-component-addon/index.js
@@ -1,0 +1,16 @@
+/*jshint node:true*/
+module.exports = {
+  description: 'Generate a UI component-addon',
+
+  fileMapTokens: function() {
+    return this.lookupBlueprint('component-addon').fileMapTokens();
+  },
+
+  normalizeEntityName: function(entityName) {
+    return this.lookupBlueprint('component-addon').normalizeEntityName(entityName);
+  },
+
+  locals: function(options) {
+    return this.lookupBlueprint('component-addon').locals(options);
+  }
+};

--- a/blueprints/ui-component-kind-addon/files/__root__/__path__/__name__.js
+++ b/blueprints/ui-component-kind-addon/files/__root__/__path__/__name__.js
@@ -1,0 +1,1 @@
+export { default } from '<%= modulePath %>';

--- a/blueprints/ui-component-kind-addon/index.js
+++ b/blueprints/ui-component-kind-addon/index.js
@@ -1,0 +1,16 @@
+/*jshint node:true*/
+module.exports = {
+  description: 'Generate a UI component-addon',
+
+  fileMapTokens: function() {
+    return this.lookupBlueprint('component-addon').fileMapTokens();
+  },
+
+  normalizeEntityName: function(entityName) {
+    return this.lookupBlueprint('component-addon').normalizeEntityName(entityName);
+  },
+
+  locals: function(options) {
+    return this.lookupBlueprint('component-addon').locals(options);
+  }
+};

--- a/blueprints/ui-component-kind/files/__root__/__path__/__name__.js
+++ b/blueprints/ui-component-kind/files/__root__/__path__/__name__.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+<%= importTemplate %>
+export default Ember.Component.extend({<%= contents %>,
+  tagName: ''
+});

--- a/blueprints/ui-component-kind/files/__root__/__templatepath__/__templatename__.hbs
+++ b/blueprints/ui-component-kind/files/__root__/__templatepath__/__templatename__.hbs
@@ -1,0 +1,3 @@
+<div class=":component {{classes.class}} {{classes.size}}">
+  {{yield}}
+</div>

--- a/blueprints/ui-component-kind/files/__root__/styles/__path__/__name__.scss
+++ b/blueprints/ui-component-kind/files/__root__/styles/__path__/__name__.scss
@@ -1,0 +1,2 @@
+@component() {
+}

--- a/blueprints/ui-component-kind/index.js
+++ b/blueprints/ui-component-kind/index.js
@@ -1,0 +1,24 @@
+/*jshint node:true*/
+module.exports = {
+  description: 'Generate a UI Component Kind',
+
+  availableOptions: [
+    {
+      name: 'path',
+      type: String,
+      default: 'components'
+    }
+  ],
+
+  fileMapTokens: function() {
+    return this.lookupBlueprint('component').fileMapTokens();
+  },
+
+  normalizeEntityName: function(entityName) {
+    return this.lookupBlueprint('component').normalizeEntityName(entityName);
+  },
+
+  locals: function(options) {
+    return this.lookupBlueprint('component').locals(options);
+  }
+};

--- a/blueprints/ui-component/files/__root__/__path__/__name__.js
+++ b/blueprints/ui-component/files/__root__/__path__/__name__.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+<%= importTemplate %>
+export default Ember.Component.extend({<%= contents %>,
+  tagName: '',
+
+  disabled: false,
+  kind: 'default',
+  size: 'medium',
+
+  classes: Ember.computed('class', 'size', function() {
+    return {
+      class: this.get('class'),
+      size: `ui-font-size--${this.get('size')}`
+    }
+  }),
+
+  frame: Ember.computed('kind', function() {
+    return `<%= dasherizedModuleName %>--${this.get('kind')}`;
+  })
+});

--- a/blueprints/ui-component/files/__root__/__templatepath__/__templatename__.hbs
+++ b/blueprints/ui-component/files/__root__/__templatepath__/__templatename__.hbs
@@ -1,0 +1,6 @@
+{{#component frame
+  classes=classes
+  kind=kind
+  size=size as |component|}}
+    {{yield component}}
+{{/component}}

--- a/blueprints/ui-component/files/__root__/styles/__path__/__name__--base.scss
+++ b/blueprints/ui-component/files/__root__/styles/__path__/__name__--base.scss
@@ -1,0 +1,2 @@
+@component() {
+}

--- a/blueprints/ui-component/index.js
+++ b/blueprints/ui-component/index.js
@@ -1,0 +1,24 @@
+/*jshint node:true*/
+module.exports = {
+  description: 'Generate a UI component',
+
+  availableOptions: [
+    {
+      name: 'path',
+      type: String,
+      default: 'components'
+    }
+  ],
+
+  fileMapTokens: function() {
+    return this.lookupBlueprint('component').fileMapTokens();
+  },
+
+  normalizeEntityName: function(entityName) {
+    return this.lookupBlueprint('component').normalizeEntityName(entityName);
+  },
+
+  locals: function(options) {
+    return this.lookupBlueprint('component').locals(options);
+  }
+};


### PR DESCRIPTION
There's another issue opened for DRYing this up a little bit by extracting some of the commonalities to base classes https://github.com/prototypal-io/untitled-ui/issues/33

In the future, I'd like to figure out a cleaner way of extending the default component blueprints so we can get the default generated tests and imports without needing to worry about getting out of sync with those in ember itself.

This adds the following blueprints to allow for easier component generation:
### ui-component Blueprint

``` bash
$ ember g ui-component ui-list
installing ui-component
  create addon/components/ui-list.js
  create addon/templates/components/ui-list.hbs
  create addon/styles/components/ui-list--base.scss
installing ui-component-addon
  create app/components/ui-list.js
```

``` js
// addon/components/ui-list.js
import Ember from 'ember';
import layout from '../templates/components/ui-list';

export default Ember.Component.extend({
  layout,
  tagName: '',

  disabled: false,
  kind: 'default',
  size: 'medium',

  classes: Ember.computed('class', 'size', function() {
    return {
      class: this.get('class'),
      size: `ui-font-size--${this.get('size')}`
    }
  }),

  frame: Ember.computed('kind', function() {
    return `ui-list--${this.get('kind')}`;
  })
});
```

``` hbs
{{!-- addon/templates/components/ui-list.js --}}
{{#component frame
  classes=classes
  kind=kind
  size=size as |component|}}
    {{yield component}}
{{/component}}
```

``` sass
// addon/styles/components/ui-list--base.scss
@component() {
}
```
### ui-component-kind

``` bash
$ ember g ui-component-kind ui-list--default
installing ui-component-kind
  create addon/components/ui-list--default.js
  create addon/templates/components/ui-list--default.hbs
  create addon/styles/components/ui-list--default.scss
installing ui-component-kind-addon
  create app/components/ui-list--default.js
```

``` js
// addon/components/ui-list--default.js
import Ember from 'ember';
import layout from '../templates/components/ui-list--default';

export default Ember.Component.extend({
  layout,
  tagName: ''
});
```

``` hbs
{{!- addon/templates/components/ui-list--default.hbs --}}
<div class=":component {{classes.class}} {{classes.size}}">
  {{yield}}
</div>
```

``` sass
// addon/styles/components/ui-list--default.scss
@component() {
}
```
