### PR TITLE
Remove duplicate wrapper divs

### DIFF
--- a/addon/templates/components/ui-panel--default-content.hbs
+++ b/addon/templates/components/ui-panel--default-content.hbs
@@ -1,3 +1,3 @@
-<div class=":component">
+<div class=":component {{classes.class}} {{classes.size}}">
   {{yield}}
 </div>

--- a/addon/templates/components/ui-panel--default-titlebar.hbs
+++ b/addon/templates/components/ui-panel--default-titlebar.hbs
@@ -1,3 +1,3 @@
-<div class=":component">
+<div class=":component {{classes.class}} {{classes.size}}">
   {{yield}}
 </div>

--- a/addon/templates/components/ui-panel-content.hbs
+++ b/addon/templates/components/ui-panel-content.hbs
@@ -1,7 +1,5 @@
-<div class=":component">
-  {{#component frame
-    kind=kind
-    size=size}}
-      {{yield}}
-  {{/component}}
-</div>
+{{#component frame
+  kind=kind
+  size=size}}
+    {{yield}}
+{{/component}}

--- a/addon/templates/components/ui-panel-titlebar.hbs
+++ b/addon/templates/components/ui-panel-titlebar.hbs
@@ -1,7 +1,5 @@
-<div class=":component">
-  {{#component frame
-    kind=kind
-    size=size as |component|}}
-      {{yield component}}
-  {{/component}}
-</div>
+{{#component frame
+  kind=kind
+  size=size as |component|}}
+    {{yield component}}
+{{/component}}


### PR DESCRIPTION
This removes two `<div>` tags that were duplicates of those used inside
the kind components.

For example, from:

``` hbs
<div class="ui-panel--default-content ui-font-size--medium">
  <div class="ui-panel--default-content ui-font-size--medium">
    Hello World
  </div>
</div>
```

to

``` hbs
<div class="ui-panel--default-content ui-font-size--medium">
  Hello World
</div>
```

This also ensures that user-assigned `class` and `size` are respected
