### PR TITLE
Add {{ui-state}} helper

### DIFF
--- a/addon/helpers/ui-state.js
+++ b/addon/helpers/ui-state.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export function uiState([values, ...states]) {
+  let classes = [];
+
+  states.forEach((state) => {
+    if (values[state]) {
+      classes.push(state);
+    }
+  });
+
+  return classes.join(' ');
+}
+
+export default Ember.Helper.helper(uiState);

--- a/addon/templates/components/ui-button--default.hbs
+++ b/addon/templates/components/ui-button--default.hbs
@@ -1,13 +1,10 @@
 <button
   {{action action.onclick}}
   disabled={{isDisabled}}
-  class="{{classes.size}}
+  class=":component
+         {{classes.size}}
          {{classes.class}}
-         :component
-         {{if states.active 'active'}}
-         {{if states.focus 'focus'}}
-         {{if states.disabled 'disabled'}}
-         {{if states.loading 'loading'}}
+         {{ui-state states 'active' 'focus' 'disabled' 'loading'}}
          {{if group 'group-button'}}
          {{if group.isFirstChild 'first-child'}}
          {{if group.isLastChild 'last-child'}}">

--- a/addon/templates/components/ui-button--material.hbs
+++ b/addon/templates/components/ui-button--material.hbs
@@ -2,12 +2,9 @@
   <button
     {{action action.onclick}}
     disabled={{isDisabled}}
-    class="{{classes.size}}
-           :component
-           {{if states.active 'active'}}
-           {{if states.focus 'focus'}}
-           {{if states.disabled 'disabled'}}
-           {{if states.loading 'loading'}}">
+    class=":component
+           {{classes.size}}
+           {{ui-state states 'active' 'focus' 'disabled' 'loading'}}">
       <div class="label">
         {{yield}}
       </div>

--- a/addon/templates/components/ui-checkbox--default.hbs
+++ b/addon/templates/components/ui-checkbox--default.hbs
@@ -2,9 +2,7 @@
               {{classes.size}}
               {{classes.class}}
               {{unless states.disabled 'enabled'}}
-              {{if states.disabled 'disabled'}}
-              {{if states.checked 'checked'}}
-              {{if states.error 'error'}}">
+              {{ui-state states 'disabled' 'checked' 'error'}}">
   {{input
     class="ui-checkbox--default--input"
     type="checkbox"

--- a/app/helpers/ui-state.js
+++ b/app/helpers/ui-state.js
@@ -1,0 +1,1 @@
+export { default, uiState } from 'untitled-ui/helpers/ui-state';

--- a/tests/unit/helpers/ui-state-test.js
+++ b/tests/unit/helpers/ui-state-test.js
@@ -1,0 +1,20 @@
+import { uiState } from 'dummy/helpers/ui-state';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | ui state');
+
+test('returns truthful states', function(assert) {
+  let states = { active: true, loading: true, disabled: false }
+
+  let result = uiState([states, 'active', 'loading', 'disabled']);
+
+  assert.equal(result, 'active loading', 'truthy states returned');
+});
+
+test('skips truthful states that are not asked for', function(assert) {
+  let states = { active: true, notAskedFor: true  }
+
+  let result = uiState([states, 'active']);
+
+  assert.equal(result, 'active', 'state that was not asked for not included');
+});


### PR DESCRIPTION
Part of #16

This helper allows you to pass in the value for all of your states and
then specify which ones you're interested in applying on a given
element.

Each of the specified states that are set to `true` are joined into a
single string that is returned.

I updated to spots in the that could make use of this as an example. I can update the rest after we determine if this is good.
