### PR TITLE
Use base classes for dropbutton & subcomponents

### DIFF
--- a/addon/components/icons/icon-dropbutton.js
+++ b/addon/components/icons/icon-dropbutton.js
@@ -1,7 +1,6 @@
-import Ember from 'ember';
+import UIKindComponent from '../ui-kind';
 import layout from 'untitled-ui/templates/components/icons/icon-dropbutton';
 
-export default Ember.Component.extend({
-  layout,
-  tagName: ''
+export default UIKindComponent.extend({
+  layout
 });

--- a/addon/components/ui-dropbutton-trigger--default.js
+++ b/addon/components/ui-dropbutton-trigger--default.js
@@ -1,7 +1,6 @@
-import Ember from 'ember';
+import UIKindComponent from './ui-kind';
 import layout from 'untitled-ui/templates/components/ui-dropbutton-trigger--default';
 
-export default Ember.Component.extend({
-  layout,
-  tagName: ''
+export default UIKindComponent.extend({
+  layout
 });

--- a/addon/components/ui-dropbutton-trigger.js
+++ b/addon/components/ui-dropbutton-trigger.js
@@ -1,21 +1,6 @@
-import Ember from 'ember';
+import UIComponent from './ui-component';
 import layout from 'untitled-ui/templates/components/ui-dropbutton-trigger';
 
-export default Ember.Component.extend({
-  layout,
-  tagName: '',
-
-  kind: 'default',
-  size: 'medium',
-
-  frame: Ember.computed('kind', function() {
-    return `ui-dropbutton-trigger--${this.get('kind')}`;
-  }),
-
-  classes: Ember.computed('size', function() {
-    return {
-      size: `ui-font-size--${this.get('size')}`,
-      class: this.get('class')
-    }
-  })
+export default UIComponent.extend({
+  layout
 });

--- a/addon/components/ui-dropbutton.js
+++ b/addon/components/ui-dropbutton.js
@@ -1,26 +1,13 @@
 import Ember from 'ember';
+import UIComponent from './ui-component';
 import layout from 'untitled-ui/templates/components/ui-dropbutton';
 
-export default Ember.Component.extend({
+export default UIComponent.extend({
   layout,
-  tagName: '',
 
-  kind: 'default',
-  size: 'medium',
   disabled: false,
   loading: false,
   showPopup: false,
-
-  frame: Ember.computed('kind', function() {
-    return `ui-dropbutton--${this.get('kind')}`;
-  }),
-
-  classes: Ember.computed('size', function() {
-    return {
-      size: `ui-font-size--${this.get('size')}`,
-      class: this.get('class')
-    }
-  }),
 
   isDisabled: Ember.computed.or('disabled', 'loading'),
 

--- a/addon/components/ui-popup--dropbutton.js
+++ b/addon/components/ui-popup--dropbutton.js
@@ -1,7 +1,6 @@
-import Ember from 'ember';
+import UIKindComponent from './ui-kind';
 import layout from '../templates/components/ui-popup--dropbutton';
 
-export default Ember.Component.extend({
-  layout,
-  tagName: ''
+export default UIKindComponent.extend({
+  layout
 });


### PR DESCRIPTION
Updates `{{ui-dropbutton}}` and related components added in https://github.com/prototypal-io/untitled-ui/commit/e0323b421fe17154686d629f9441db07812a3101 to extend from base classes added in #50 
