### PR TITLE
Use moduleName rather than prefix

### DIFF
--- a/lib/js-preprocessor/broccoli-generate-components.js
+++ b/lib/js-preprocessor/broccoli-generate-components.js
@@ -23,7 +23,7 @@ function GenerateComponents(inputTree, options) {
 }
 
 GenerateComponents.prototype.build = function() {
-  var components = componentsToGenerate(this.baseDir, this.scss, this.prefix);
+  var components = componentsToGenerate(this.baseDir, this.scss, this.moduleName);
 
   components.forEach(function(hash) {
     this.generateFile(hash.component, hash.default);
@@ -60,9 +60,9 @@ GenerateComponents.prototype.appComponentFor = function(fileName) {
   return "export { default } from '" + defaultModule + "';\n";
 };
 
-var componentsToGenerate = function(baseDir, scss, modulePrefix) {
+var componentsToGenerate = function(baseDir, scss, moduleName) {
   var scssFiles = walkSync(baseDir, { globs: scss });
-  var baseKindFile = path.join(modulePrefix, 'components', 'ui-kind').replace('modules/', '');
+  var baseKindFile = path.join(moduleName, 'components', 'ui-kind');
 
   var expectedJsFiles = scssFiles.map(function(fileName) {
     return fileName.replace(/^styles\/components\/(.+)\.scss/, 'components/$1.js');


### PR DESCRIPTION
Uses `moduleName` rather than `prefix` for determining path to `ui-kind` component.
