### PR TITLE
Optimize CSS via broccoli-csso

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var path = require('path');
+var csso = require('broccoli-csso');
 
 var jsPreprocessor = require('./lib/js-preprocessor');
 var templatePreprocessor = require('./lib/template-preprocessor');
@@ -90,6 +91,14 @@ module.exports = {
       name: 'transform-component-classes',
       plugin: TransformComponentClasses
     });
+  },
+
+  postprocessTree: function(type, tree) {
+    if (type === 'css') {
+      tree = csso(tree);
+    }
+
+    return tree;
   },
 
   addonRoot: function() {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   ],
   "dependencies": {
     "broccoli-caching-writer": "^2.2.1",
+    "broccoli-csso": "^2.0.0",
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
     "broccoli-persistent-filter": "^1.2.0",


### PR DESCRIPTION
We found an existing library for optimizing CSS called [csso](https://github.com/css/csso). Integrating it into the untitled-ui build pipeline achieves combination of selectors for duplicated property sets, along with other optimizations. The size of `vendor.css` dropped from 126961 to 82588, a savings of ~35%.

/cc @dipiep @ebryn 
