### PR TITLE
Use dynamic prefix value for component classes

### DIFF
--- a/addon/components/ui-component.js
+++ b/addon/components/ui-component.js
@@ -2,17 +2,17 @@ import Ember from 'ember';
 import layout from '../templates/components/ui-component';
 
 export default Ember.Component.extend({
-  init() {
-    this._super(...arguments);
-
-    this.uiPrefix = this._debugContainerKey.split(':')[1];
-  },
-
   layout,
   tagName: '',
 
   kind: 'default',
   size: 'medium',
+
+  init() {
+    this._super(...arguments);
+
+    this.uiPrefix = this._debugContainerKey.split(':')[1];
+  },
 
   classes: Ember.computed('class', 'size', function() {
     return {

--- a/addon/components/ui-kind.js
+++ b/addon/components/ui-kind.js
@@ -3,6 +3,11 @@ import layout from '../templates/components/ui-kind';
 
 export default Ember.Component.extend({
   layout,
+  tagName: '',
 
-  tagName: ''
+  init() {
+    this._super(...arguments);
+
+    this.uiPrefix = this._debugContainerKey.split(':')[1];
+  }
 });

--- a/addon/helpers/-ui-component-class.js
+++ b/addon/helpers/-ui-component-class.js
@@ -19,14 +19,13 @@ export default Ember.Helper.helper(function ([prefix, ...classNames]) {
   return normalizedClassNames.reduce(function(string, name) {
     switch (true) {
       case (name === ':component'):
-        var baseClass = prefix.replace(/(.*)--$/, '$1');
-        return string += `${baseClass} `;
+        return string += `${prefix} `;
       case (FONT_SIZE_PATTERN.test(name)):
         return string += `${name} `;
       case (name === 'fa' || FONTAWESOME_PATTERN.test(name)):
         return string += `${name} `;
       default:
-        return string += `${prefix}${name} `;
+        return string += `${prefix}--${name} `;
     }
   }, '');
 });

--- a/lib/transform-component-classes.js
+++ b/lib/transform-component-classes.js
@@ -1,5 +1,4 @@
 var COMPONENT_MODULE_PATTERN = /.+\/components\/.+/;
-var COMPONENT_NAME_PATTERN = /.+\/components\/(.+)\.hbs/;
 
 function TransformComponentClasses(options) {
   this.syntax = null;
@@ -43,8 +42,14 @@ TransformComponentClasses.prototype = {
 
   transformClassAttr: function (classAttrNode) {
     var value = classAttrNode.value;
-    var prefix = this.options.moduleName.match(COMPONENT_NAME_PATTERN)[1] + '--';
     var params;
+
+    var prefix = {
+      type: 'PathExpression',
+      original: 'uiPrefix',
+      parts: [ 'uiPrefix' ]
+    };
+
     switch (value.type) {
       case 'TextNode': // class="foo bar"
         params = paramsFromTextNode(value, prefix);
@@ -84,11 +89,7 @@ function makeMustacheAnExpression(mustacheStatement) {
 }
 
 function paramsFromTextNode(textNode, prefix) {
-  return [{
-    type: 'StringLiteral',
-    original: prefix,
-    value: prefix
-  }, {
+  return [prefix, {
     type: "StringLiteral",
     value: textNode.chars,
     original: textNode.chars
@@ -97,11 +98,7 @@ function paramsFromTextNode(textNode, prefix) {
 
 function paramsFromConcatStatement(concatStatement, prefix) {
   var params = concatStatement.parts;
-  return [{
-    type: 'StringLiteral',
-    original: prefix,
-    value: prefix
-  }].concat(concatStatement.parts.map(function (node) {
+  return [prefix].concat(concatStatement.parts.map(function (node) {
     if (node.type === 'MustacheStatement') {
       return makeMustacheAnExpression(node);
     }
@@ -111,11 +108,7 @@ function paramsFromConcatStatement(concatStatement, prefix) {
 
 function paramsFromMustacheStatement(mustacheStatement, prefix) {
   mustacheStatement.type = 'SubExpression';
-  return [{
-    type: 'StringLiteral',
-    original: prefix,
-    value: prefix
-  }, makeMustacheAnExpression(mustacheStatement)];
+  return [prefix, makeMustacheAnExpression(mustacheStatement)];
 }
 
 module.exports = TransformComponentClasses;


### PR DESCRIPTION
This gets all the tests back passing by passing a dynamic value into the `-ui-component-class` helper in the templates.

Basically, the template transform was doing:

``` hbs
<!-- app/templates/components/ui-panel--default.hbs -->
<div class=":component foo"></div>

<!-- transformed to -->
<div class="{{-ui-component-class 'ui-panel--default' 'foo'}}></div>
```

Which now transforms to:

``` hbs
<!-- app/templates/components/ui-panel--default.hbs -->
<div class=":component foo"></div>

<!-- transformed to -->
<div class="{{-ui-component-class uiPrefix 'foo'}}></div>
```

This allows layouts to be shared between components (such as the defaults) because the `moduleName` of the template is not hard coded.
