### PR TITLE
Add example "tomato" theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 npm-debug.log
 testem.log
 .DS_Store
+
+/lib/ui-tomato/node_modules

--- a/lib/.jshintrc
+++ b/lib/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "node": true,
+  "browser": false
+}

--- a/lib/ui-tomato/addon/components/tomato--ui-panel--default.js
+++ b/lib/ui-tomato/addon/components/tomato--ui-panel--default.js
@@ -1,0 +1,6 @@
+import UIPanelDefault from 'untitled-ui/components/ui-panel--default';
+import layout from 'untitled-ui/templates/components/ui-panel--default';
+
+export default UIPanelDefault.extend({
+  layout
+});

--- a/lib/ui-tomato/addon/instance-initializers/ui-theme.js
+++ b/lib/ui-tomato/addon/instance-initializers/ui-theme.js
@@ -1,0 +1,10 @@
+export function initialize(appInstance) {
+  // let themeService = appInstance.lookup('service:ui-theme');
+
+  // themeService.register('ui-panel', 'default', 'tomato');
+}
+
+export default {
+  name: 'ui-themes/tomato',
+  initialize
+};

--- a/lib/ui-tomato/addon/styles/components/tomato--ui-panel--default.scss
+++ b/lib/ui-tomato/addon/styles/components/tomato--ui-panel--default.scss
@@ -1,0 +1,12 @@
+// @import './ui-panel--default';
+
+@component {
+  // @include ui-panel--default($background: tomato);
+
+  color: #ffffff;
+  background-image: none;
+
+  &--wrapper {
+    background: tomato;
+ }
+}

--- a/lib/ui-tomato/addon/templates/components/tomato--ui-panel--default.hbs
+++ b/lib/ui-tomato/addon/templates/components/tomato--ui-panel--default.hbs
@@ -1,0 +1,7 @@
+<div class=":component {{classes.size}}">
+  <div class="wrapper">
+    {{yield (hash
+      titlebar=(component "ui-panel--default-titlebar")
+      content=(component "ui-panel--default-content"))}}
+  </div>
+</div>

--- a/lib/ui-tomato/app/components/tomato--ui-panel--default.js
+++ b/lib/ui-tomato/app/components/tomato--ui-panel--default.js
@@ -1,0 +1,1 @@
+export { default } from 'ui-tomato/components/tomato--ui-panel--default';

--- a/lib/ui-tomato/app/instance-initializers/ui-theme.js
+++ b/lib/ui-tomato/app/instance-initializers/ui-theme.js
@@ -1,0 +1,1 @@
+export { default, initialize } from 'ui-tomato/instance-initializers/ui-theme';

--- a/lib/ui-tomato/index.js
+++ b/lib/ui-tomato/index.js
@@ -1,0 +1,34 @@
+/*jshint node:true*/
+var scssPreprocessor = require('../scss-preprocessor');
+
+module.exports = {
+  name: 'ui-tomato',
+
+  isDevelopingAddon: function() {
+    return true;
+  },
+
+  included: function(app, parentAddon) {
+    var target = (parentAddon || app);
+    target.options = target.options || {};
+    target.options.babel = target.options.babel || { includePolyfill: true };
+    return this._super.included(target);
+  },
+
+  setupPreprocessorRegistry: function(type, registry) {
+    if (type === 'self') {
+      this.setupCssPreprocessing(registry);
+    }
+  },
+
+  setupCssPreprocessing: function(registry) {
+    registry.add('css', {
+      name: 'mixin-classes',
+      toTree: function(tree) {
+        return scssPreprocessor(tree, {
+          components: 'components/*.scss'
+        });
+      }
+    });
+  }
+};

--- a/lib/ui-tomato/package.json
+++ b/lib/ui-tomato/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ui-tomato",
+  "keywords": [
+    "ember-addon"
+  ],
+  "dependencies": {
+    "broccoli-caching-writer": "^2.2.1",
+    "broccoli-funnel": "^1.0.1",
+    "ember-cli-babel": "^5.1.6",
+    "ember-cli-htmlbars": "^1.0.5",
+    "ember-cli-sass": "^5.3.1",
+    "exists-sync": "0.0.3",
+    "mkdirp": "^0.5.1",
+    "symlink-or-copy": "^1.1.3",
+    "walk-sync": "^0.2.6"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
     "walk-sync": "^0.2.6"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "paths": [
+      "lib/ui-tomato"
+    ]
   }
 }

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -684,4 +684,20 @@
   {{/panel.content}}
 {{/ui-panel}}
 
+{{#ui-panel theme="tomato" as |panel|}}
+  {{#panel.titlebar}}
+    Themed Panel
+  {{/panel.titlebar}}
+
+  {{#panel.content}}
+    <h3>Basic List</h3>
+
+    {{#ui-list as |list|}}
+      {{#list.item}}Red{{/list.item}}
+      {{#list.item}}Green{{/list.item}}
+      {{#list.item}}Blue{{/list.item}}
+    {{/ui-list}}
+  {{/panel.content}}
+{{/ui-panel}}
+
 {{outlet}}


### PR DESCRIPTION
This adds an in-repo addon that acts as an example ui-theme.

More work needs to be done in order to take advantage of the same automatic generation that is going on the base addon, not just with the javascript files but also with the stylesheets.
