### PR TITLE
Components middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "ember-addon"
   ],
   "dependencies": {
-    "body-parser": "^1.15.2",
     "broccoli-caching-writer": "^2.2.1",
     "broccoli-csso": "^2.0.0",
     "broccoli-funnel": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-addon"
   ],
   "dependencies": {
+    "body-parser": "^1.15.2",
     "broccoli-caching-writer": "^2.2.1",
     "broccoli-csso": "^2.0.0",
     "broccoli-funnel": "^1.0.1",

--- a/theme.js
+++ b/theme.js
@@ -9,7 +9,6 @@ var ThemeCore = require('./lib/theme-core');
 var TransformComponentClasses = require('./lib/htmlbars-plugins/transform-component-classes');
 var TransformUITableComponents = require('./lib/htmlbars-plugins/transform-ui-table-components');
 var funnel = require('broccoli-funnel');
-var bodyParser = require('body-parser');
 var walkSync = require('walk-sync');
 
 var themeCore;
@@ -93,12 +92,6 @@ var Theme = Addon.extend({
   serverMiddleware: function(config) {
     var app = config.app;
     var themeCore = this.themeCore;
-
-    // do we want the body parser middleware for all
-    // routes or just the route defined below?
-    // i believe there's a way to just add it to that one
-    // @heroiceric
-    app.use(bodyParser.json());
 
     app.get('/__ui/components', function(req, res, next) {
       // var demoComponents =


### PR DESCRIPTION
This adds some ember-cli middleware that adds an endpoint that can be used to fetch information about UI components and dynamically create the styleguide.

The response looks like:

``` js
// GET /__ui/themes

[{
  name: 'ui-base-theme',
  components: [{
    name: 'ui-button-group',
    file: 'components/ui-button-group.js',
    modulePath: 'dummy/components/ui-button-group',
    demoFile: 'components/demo--ui-button-group.js',
    demoName: 'demo--ui-button-group',
    kinds: ['default', 'material', 'primary', 'simple'],
  }, {
    name: 'ui-button',
    file: 'components/ui-button.js',
    modulePath: 'dummy/components/ui-button',
    demoFile: 'components/demo--ui-button.js',
    demoName: 'demo--ui-button',
    kinds: ['default', 'material', 'primary', 'simple']
  }, ...]
}]
```
### TODO
- [ ] Dynamically determine `states`
- [ ] Dynamically determine `kinds`
