### PR TITLE
Dynamic Kinds

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -117,7 +117,7 @@ var Theme = Addon.extend({
 
           var demoComponentName = demoComponentFile && demoComponentFile.replace(/^components\/(.*).js$/, '$1');
 
-          var kindRegExp = new RegExp('^components/' + name + '--(.*).scss$');
+          var kindRegExp = new RegExp('^components/' + name + '--(?!base|-)(.*).scss$');
           var kinds =
             allScssFiles
             .filter((scssFile) => scssFile.match(kindRegExp))

--- a/theme.js
+++ b/theme.js
@@ -97,6 +97,7 @@ var Theme = Addon.extend({
     app.get('/__ui/themes', function(req, res, next) {
       var themes = themeCore.themes.map(function(theme) {
         var allComponentFiles = theme.toJsComponentFilesArray();
+        var allScssFiles = theme.toScssComponentFilesArray();
 
         var demoComponentFiles = allComponentFiles.filter(function(componentFile) {
           return /^components\/demo--(.*).js$/.test(componentFile);
@@ -116,13 +117,19 @@ var Theme = Addon.extend({
 
           var demoComponentName = demoComponentFile && demoComponentFile.replace(/^components\/(.*).js$/, '$1');
 
+          var kindRegExp = new RegExp('^components/' + name + '--(.*).scss$');
+          var kinds =
+            allScssFiles
+            .filter((scssFile) => scssFile.match(kindRegExp))
+            .map((scssFile) => scssFile.match(kindRegExp)[1]);
+
           return {
             name: name,
             modulePath: modulePath,
             file: componentFile,
             demoFile: demoComponentFile,
             demoComponentName: demoComponentName,
-            kinds: ['default', 'material', 'primary', 'simple'] // TODO: Determine dynamically
+            kinds: kinds
           };
         });
 
@@ -140,8 +147,13 @@ var Theme = Addon.extend({
   },
 
   toJsComponentFilesArray: function() {
-    var scssDir = path.join(this._baseDiskDir(), this.jsPath);
-    return walkSync(scssDir, { globs: ['components/*.js'] });
+    var jsDir = path.join(this._baseDiskDir(), this.jsPath);
+    return walkSync(jsDir, { globs: ['components/*.js'] });
+  },
+
+  toScssComponentFilesArray: function() {
+    var scssDir = path.join(this._baseDiskDir(), this.scssPath);
+    return walkSync(scssDir, { globs: ['components/*.scss'] });
   },
 
   _baseDiskDir: function() {


### PR DESCRIPTION
This attempts to use the component scss files in order to find all of the kinds for a given component by using a `RegExp`. This doesn't really work with the current state of things.
### Issues

![screen shot 2016-08-02 at 12 06 26 pm](https://cloud.githubusercontent.com/assets/602204/17341668/8856845c-58aa-11e6-904d-205161c17ab3.png)

This relies on file naming conventions (😿 ), which currently doesn't provide a way to determine whether a file is for a kind or a contextual component.

Here's a sample of what the scss files look like for the `ui-panel`:

``` js
[
  'components/ui-panel--default.js',
  'components/ui-panel--ios-titlebar.js',
  'components/ui-panel--ios.js',
  'components/ui-panel-titlebar.js',
  'components/ui-panel.js'
]
```

We want to match on the `components/ui-panel--ios.js` because `ios` is a valid kind but we need to reject the contextual components for the kind, like `components/ui-panel--ios-titlebar`.
