### PR TITLE
Improve component mixin import paths

### DIFF
--- a/lib/scss-preprocessor/broccoli-transform-components.js
+++ b/lib/scss-preprocessor/broccoli-transform-components.js
@@ -11,8 +11,6 @@ function extract(pattern, string) {
 function Transform(inputTree, options) {
   Filter.call(this, inputTree, options);
 
-  this.moduleNamespace = options.moduleNamespace;
-  this.stylesNamespace = options.stylesNamespace;
   this.componentsNamespace = options.componentsNamespace;
 }
 
@@ -34,7 +32,7 @@ Transform.prototype.processString = function(content, relPath) {
 };
 
 Transform.prototype.namePattern = function() {
-  return new RegExp('^'+this.moduleNamespace+'\/.+\/'+this.stylesNamespace+'\/'+this.componentsNamespace+'\/(.+)\.scss$');
+  return new RegExp('^.+\/'+this.componentsNamespace+'\/(.+)\.scss$');
 };
 
 Transform.prototype.replaceWithMixin = function(content, name) {

--- a/lib/scss-preprocessor/index.js
+++ b/lib/scss-preprocessor/index.js
@@ -10,28 +10,26 @@ var TransformComponents = require('./broccoli-transform-components');
 var ImportThemeComponents = require('./broccoli-import-theme-components');
 var ProvideAppImports = require('./broccoli-provide-app-imports');
 
+var stew = require('broccoli-stew');
+
 module.exports = function(tree, options) {
   var themes = options.themes || [];
-  var moduleNamespace = options.moduleNamespace;
-  var stylesNamespace = options.stylesNamespace;
   var componentsNamespace = options.componentsNamespace;
   var scssMainFilePath = 'app/styles/app.scss';
 
   var themeTrees = themes.reduce(function(trees, theme) {
     var themeTree = theme.toScssTree();
     themeTree = funnel(themeTree, {
-      destDir: path.join(moduleNamespace, theme.name, stylesNamespace)
+      destDir: path.join(theme.name)
     });
     themeTree = new TransformComponents(themeTree, {
-      moduleNamespace: moduleNamespace,
-      stylesNamespace: stylesNamespace,
       componentsNamespace: componentsNamespace
     });
 
-    var themeMain = path.join(moduleNamespace, theme.name, stylesNamespace, theme.name + '.scss');
+    var themeMain = path.join(theme.name, theme.name + '.scss');
     themeTree = new ImportThemeComponents(themeTree, {
       main: themeMain,
-      include: [path.join(moduleNamespace, theme.name, stylesNamespace, componentsNamespace, '*.scss')]
+      include: [path.join(theme.name, componentsNamespace, '*.scss')]
     });
 
     var appImport = new ProvideAppImports(themeTree, {
@@ -47,6 +45,9 @@ module.exports = function(tree, options) {
   }, []);
 
   var scssTree = funnel(tree, { include: ['**/*.scss'] });
-  scssTree = mergeTrees([scssTree].concat(themeTrees));
-  return scssTree;
+  scssTree = mergeTrees([scssTree].concat(themeTrees), { overwrite: true });
+
+  var loggedTree = stew.log(scssTree, { output: 'tree', label: 'my-app-name tree' });
+
+  return loggedTree;
 };


### PR DESCRIPTION
The goal here is to improve the paths used to import component mixins in sub themes.

Currently you need to do something like:

``` scss
@import "modules/ui-base-theme/styles/components/ui-button--default";

@component {
  @include ui-button--default($background: tomato);
}
```

With these changes you can use:

``` scss
@import "ui-base-theme/components/ui-button--default";

@component {
  @include ui-button--default($background: tomato);
}
```

~~I need to do further investigation to make sure this doesn't affect the rest of the build tools.~~
