### PR TITLE
Add {{ui-root}} template transform

### DIFF
--- a/lib/htmlbars-plugins/transform-ui-root.js
+++ b/lib/htmlbars-plugins/transform-ui-root.js
@@ -1,0 +1,105 @@
+/**
+  Replaces
+
+  ```handlebars
+  <div {{ui-root}}></div>
+  <div {{ui-root}} class="foo"></div>
+  ```
+
+  with
+
+  ```handlebars
+  <div class=":component {{classes.class}} {{classes.size}}"></div>
+  <div class=":component {{classes.class}} {{classes.size}} foo"></div>
+  ```
+*/
+
+function TransformUIRoot(options) {
+  this.syntax = null;
+  this.options = options;
+}
+
+TransformUIRoot.prototype.transform = function(ast) {
+  var b = this.syntax.builders;
+  var traverse = this.syntax.traverse;
+
+  traverse(ast, {
+    ElementNode: function(node) {
+      if (isUIRootNode(node)) {
+        node = transformUIRootNode(node, b);
+      }
+
+      return node;
+    }
+  });
+
+  return ast;
+};
+
+function isUIRootNode(node) {
+  var rootModifiers = node.modifiers.filter(function(modifier) {
+    return modifier.path.original === 'ui-root';
+  });
+
+  return rootModifiers.length > 0;
+}
+
+function transformUIRootNode(node, b) {
+  var newAttributes = withoutExistingClassAttr(node.attributes);
+  var existingClassAttr = findExistingClassAttr(node.attributes);
+  var rootClassAttr = buildRootClassAttr(b, existingClassAttr);
+
+  newAttributes.push(rootClassAttr)
+
+  node.attributes = newAttributes;
+}
+
+function buildRootClassAttr(b, existingClassAttr) {
+  var parts = [
+    b.string(':component '),
+    b.path('classes.class'),
+    b.string(' '),
+    b.path('classes.size'),
+    b.string(' ')
+  ];
+
+  if (existingClassAttr) {
+    parts.push(transformClassAttrValue(existingClassAttr.value, b));
+  }
+
+  return b.attr('class', b.concat(parts));
+}
+
+function withoutExistingClassAttr(attributes) {
+  return attributes.filter(function(attr) {
+    return attr.name !== 'class';
+  });
+}
+
+function findExistingClassAttr(attributes) {
+  return attributes.filter(function(attr) {
+    return attr.name === 'class';
+  })[0];
+}
+
+function transformClassAttrValue(value, b) {
+  switch (value.type) {
+    case 'TextNode':
+      return b.string(value.chars);
+    case 'ConcatStatement':
+      return b.sexpr('concat', value.parts.map(function(part) {
+        if (part.type === 'MustacheStatement') {
+          part.type = 'SubExpression';
+        }
+
+        return part;
+      }));
+    case 'MustacheStatement':
+      value.type = 'SubExpression';
+      return value;
+    default:
+      throw new Error('unrecognized node type "' + value.type + '" for class attribute value');
+  }
+}
+
+module.exports = TransformUIRoot;

--- a/theme.js
+++ b/theme.js
@@ -7,6 +7,7 @@ var path = require('path');
 var Addon = require('ember-cli/lib/models/addon');
 var ThemeCore = require('./lib/theme-core');
 var TransformComponentClasses = require('./lib/htmlbars-plugins/transform-component-classes');
+var TransformUIRoot = require('./lib/htmlbars-plugins/transform-ui-root');
 var TransformUITableComponents = require('./lib/htmlbars-plugins/transform-ui-table-components');
 var funnel = require('broccoli-funnel');
 var walkSync = require('walk-sync');
@@ -63,6 +64,11 @@ var Theme = Addon.extend({
     registry.add('htmlbars-ast-plugin', {
       name: 'transform-component-classes',
       plugin: TransformComponentClasses
+    });
+
+    registry.add('htmlbars-ast-plugin', {
+      name: 'transform-ui-root',
+      plugin: TransformUIRoot
     });
 
     registry.add('htmlbars-ast-plugin', {


### PR DESCRIPTION
Closes https://github.com/prototypal-io/untitled-ui/issues/67

This adds a template transform that replaces:

``` handlebars
<div {{ui-root}}></div>
<div {{ui-root}} class="foo"></div>
```

with:

``` handlebars
<div class=":component {{classes.class}} {{classes.size}}"></div>
<div class=":component {{classes.class}} {{classes.size}} foo"></div>
```
