### PR TITLE
Create theme scope via mixins

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,5 +8,9 @@ module.exports = {
 
   postprocessTree: function(type, tree) {
     return type === 'css' ? csso(tree) : tree;
+  },
+
+  isDevelopingAddon: function() {
+    return true;
   }
 };

--- a/lib/scss-preprocessor/broccoli-import-theme-components.js
+++ b/lib/scss-preprocessor/broccoli-import-theme-components.js
@@ -12,7 +12,8 @@ function Import(inputTree, options) {
   this.include = options.include;
   this.main = options.main;
   this.themeName = options.themeName || 'ui-base';
-  this.themePrefix = options.themePrefix || 'ui-base';
+  this.themePrefix = options.themePrefix || 'base';
+  this.parentTheme = options.parentTheme;
 }
 
 Import.prototype = Object.create(Filter.prototype);
@@ -53,19 +54,57 @@ Import.prototype.addThemeComponentClasses = function(content) {
   var inputPath = this.inputPaths[0];
   var importFiles = walkSync(inputPath, { globs: this.include });
   var themePrefix = this.themePrefix;
+  var parentThemeComponentFiles = this.parentTheme ?
+    this.parentTheme.toScssComponentFilesArray() : [];
 
-  var componentClasses = importFiles.reduce(function(string, filePath) {
-    var name = path.basename(filePath).replace(themePrefix + '--', '').replace('.scss', '');
+  var themeComponents = importFiles.map(function(filePath) {
+    return path.basename(filePath).replace(themePrefix + '--', '').replace('.scss', '');
+  });
 
-    return string += '  &--' + name + ' {\n    @include ' + name + '($theme);\n  }\n\n';
-  }, '');
+  var parentThemeComponents = parentThemeComponentFiles.map(function(filePath) {
+    return filePath.replace('components\/', '').replace('.scss', '');
+  });
 
-  var themeMixin = '@mixin ' + this.themeName + '($theme...) {\n' +
-    '  $theme: keywords($theme);\n\n' +
-    componentClasses +
-  '}';
+  var themeClasses = parentThemeComponents.reduce(function(array, component) {
+    if (themeComponents.indexOf(component) === -1) {
+      var importStatement = '  &--' + component + ' {\n    @include ' + component + '($theme);\n  }\n';
+      array = array.concat(importStatement);
+    }
+
+    return array;
+  }, []);
+
+  themeClasses = themeComponents.reduce(function(array, component) {
+    var importStatement;
+
+    if (themePrefix === 'base') {
+      importStatement = '    .' + component + ' {\n      @include ' + component + '($theme);\n    }\n';
+    } else {
+      importStatement = '  &--' + component + ' {\n    @include ' + themePrefix + '--' + component + '($theme);\n  }\n';
+    }
+
+    return array.concat(importStatement);
+  }, themeClasses);
+
+  var themeMixin = this.buildThemeMixin(themeClasses);
 
   return themeMixin;
+};
+
+Import.prototype.buildThemeMixin = function(themeClasses) {
+  if (this.themePrefix === 'base') {
+    return '@mixin ' + this.themeName + '($theme...) {\n' +
+      '  $theme: keywords($theme);\n\n' +
+      '  @at-root {\n' +
+      themeClasses.join('\n') +
+      '  }\n' +
+    '}';
+  } else {
+    return '@mixin ' + this.themeName + '($theme...) {\n' +
+      '  $theme: keywords($theme);\n\n' +
+      themeClasses.join('\n') +
+    '}';
+  }
 };
 
 module.exports = Import;

--- a/lib/scss-preprocessor/broccoli-import-theme-components.js
+++ b/lib/scss-preprocessor/broccoli-import-theme-components.js
@@ -11,8 +11,8 @@ function Import(inputTree, options) {
 
   this.include = options.include;
   this.main = options.main;
-  this.themeName = options.themeName || 'ui-base';
-  this.themePrefix = options.themePrefix || 'base';
+  this.themeName = options.themeName;
+  this.themePrefix = options.themePrefix;
   this.parentTheme = options.parentTheme;
 }
 
@@ -54,37 +54,31 @@ Import.prototype.addThemeComponentClasses = function(content) {
   var inputPath = this.inputPaths[0];
   var importFiles = walkSync(inputPath, { globs: this.include });
   var themePrefix = this.themePrefix;
+  var parentThemePrefix = this.parentTheme && this.parentTheme.prefix;
   var parentThemeComponentFiles = this.parentTheme ?
     this.parentTheme.toScssComponentFilesArray() : [];
 
-  var themeComponents = importFiles.map(function(filePath) {
-    return path.basename(filePath).replace(themePrefix + '--', '').replace('.scss', '');
+  var themeComponents = kindComponentsFor(importFiles, themePrefix);
+  var parentThemeComponents = kindComponentsFor(parentThemeComponentFiles, parentThemePrefix);
+
+  var parentComponentsToImport = parentThemeComponents.filter(function(parentThemeComponent) {
+    return themeComponents.filter((function(themeComponent) {
+      return themeComponent.name === parentThemeComponent.name
+    })).length === 0;
   });
 
-  var parentThemeComponents = parentThemeComponentFiles.map(function(filePath) {
-    return filePath.replace('components\/', '').replace('.scss', '');
-  });
+  var componentsToImport = [].concat(themeComponents).concat(parentComponentsToImport);
 
-  var themeClasses = parentThemeComponents.reduce(function(array, component) {
-    if (themeComponents.indexOf(component) === -1) {
-      var importStatement = '  &--' + component + ' {\n    @include ' + component + '($theme);\n  }\n';
-      array = array.concat(importStatement);
-    }
+  var themeClasses = componentsToImport.reduce(function(array, component) {
+    var mixin = component.themePrefix + '--' + component.name + '--' + component.kind;
 
-    return array;
-  }, []);
-
-  themeClasses = themeComponents.reduce(function(array, component) {
-    var importStatement;
-
-    if (themePrefix === 'base') {
-      importStatement = '    .' + component + ' {\n      @include ' + component + '($theme);\n    }\n';
-    } else {
-      importStatement = '  &--' + component + ' {\n    @include ' + themePrefix + '--' + component + '($theme);\n  }\n';
-    }
+    var importStatement =
+      '  ' + className  + ' {\n' +
+      '    @include ' + mixin  + '($theme);\n' +
+      '  }\n';
 
     return array.concat(importStatement);
-  }, themeClasses);
+  }, []);
 
   var themeMixin = this.buildThemeMixin(themeClasses);
 
@@ -92,19 +86,26 @@ Import.prototype.addThemeComponentClasses = function(content) {
 };
 
 Import.prototype.buildThemeMixin = function(themeClasses) {
-  if (this.themePrefix === 'base') {
-    return '@mixin ' + this.themeName + '($theme...) {\n' +
-      '  $theme: keywords($theme);\n\n' +
-      '  @at-root {\n' +
-      themeClasses.join('\n') +
-      '  }\n' +
-    '}';
-  } else {
-    return '@mixin ' + this.themeName + '($theme...) {\n' +
-      '  $theme: keywords($theme);\n\n' +
-      themeClasses.join('\n') +
-    '}';
-  }
+  return '@mixin ' + this.themeName + '($theme...) {\n' +
+    '  $theme: keywords($theme);\n\n' +
+    themeClasses.join('\n') +
+  '}';
 };
+
+function kindComponentsFor(filePaths, themePrefix) {
+  var kindComponentRegExp = new RegExp(themePrefix + '--(ui-.+)--(.+).scss');
+
+  return filePaths
+    .filter(function(filePath) { return filePath.match(kindComponentRegExp); })
+    .map(function(filePath) {
+      var componentParts = filePath.match(kindComponentRegExp);
+
+      return {
+        name: matches[1],
+        themePrefix: themePrefix,
+        kind: matches[2]
+      }
+    });
+}
 
 module.exports = Import;

--- a/lib/scss-preprocessor/broccoli-import-theme-components.js
+++ b/lib/scss-preprocessor/broccoli-import-theme-components.js
@@ -70,6 +70,7 @@ Import.prototype.addThemeComponentClasses = function(content) {
   var componentsToImport = [].concat(themeComponents).concat(parentComponentsToImport);
 
   var themeClasses = componentsToImport.reduce(function(array, component) {
+    var className = '&--' + component.name + '--' + component.kind;
     var mixin = component.themePrefix + '--' + component.name + '--' + component.kind;
 
     var importStatement =
@@ -101,9 +102,9 @@ function kindComponentsFor(filePaths, themePrefix) {
       var componentParts = filePath.match(kindComponentRegExp);
 
       return {
-        name: matches[1],
+        name: componentParts[1],
         themePrefix: themePrefix,
-        kind: matches[2]
+        kind: componentParts[2]
       }
     });
 }

--- a/lib/scss-preprocessor/broccoli-import-theme-components.js
+++ b/lib/scss-preprocessor/broccoli-import-theme-components.js
@@ -11,6 +11,8 @@ function Import(inputTree, options) {
 
   this.include = options.include;
   this.main = options.main;
+  this.themeName = options.themeName || 'ui-base';
+  this.themePrefix = options.themePrefix || 'ui-base';
 }
 
 Import.prototype = Object.create(Filter.prototype);
@@ -19,7 +21,14 @@ Import.prototype.extensions = ['scss'];
 Import.prototype.targetExtension = 'scss';
 
 Import.prototype.processString = function(content, relPath) {
-  return relPath === this.main ? this.addImports(content) : content;
+  if (relPath === this.main) {
+    var imports = this.addImports(content);
+    var themeMixin = this.addThemeComponentClasses(content);
+
+    return imports + '\n' + themeMixin;
+  } else {
+    return content;
+  }
 };
 
 Import.prototype.addImports = function(content) {
@@ -38,6 +47,25 @@ Import.prototype.addImports = function(content) {
   }, '\n');
 
   return content + importsString;
+};
+
+Import.prototype.addThemeComponentClasses = function(content) {
+  var inputPath = this.inputPaths[0];
+  var importFiles = walkSync(inputPath, { globs: this.include });
+  var themePrefix = this.themePrefix;
+
+  var componentClasses = importFiles.reduce(function(string, filePath) {
+    var name = path.basename(filePath).replace(themePrefix + '--', '').replace('.scss', '');
+
+    return string += '  &--' + name + ' {\n    @include ' + name + '($theme);\n  }\n\n';
+  }, '');
+
+  var themeMixin = '@mixin ' + this.themeName + '($theme...) {\n' +
+    '  $theme: keywords($theme);\n\n' +
+    componentClasses +
+  '}';
+
+  return themeMixin;
 };
 
 module.exports = Import;

--- a/lib/scss-preprocessor/broccoli-provide-app-imports.js
+++ b/lib/scss-preprocessor/broccoli-provide-app-imports.js
@@ -38,7 +38,6 @@ Provide.prototype.addAppImports = function() {
   var importPath = path.join(this.outputPath, this.importPath);
   var relImportPath = path.relative(outDir, importPath);
   var content = "@import '"+relImportPath+"';\n";
-  console.log('content: ', content);
 
   fs.writeFileSync(outFile, content, 'utf8');
 };

--- a/lib/scss-preprocessor/broccoli-provide-app-imports.js
+++ b/lib/scss-preprocessor/broccoli-provide-app-imports.js
@@ -38,6 +38,7 @@ Provide.prototype.addAppImports = function() {
   var importPath = path.join(this.outputPath, this.importPath);
   var relImportPath = path.relative(outDir, importPath);
   var content = "@import '"+relImportPath+"';\n";
+  console.log('content: ', content);
 
   fs.writeFileSync(outFile, content, 'utf8');
 };

--- a/lib/scss-preprocessor/broccoli-transform-components.js
+++ b/lib/scss-preprocessor/broccoli-transform-components.js
@@ -25,7 +25,7 @@ Transform.prototype.processString = function(content, relPath) {
 
   if (name) {
     processed = this.replaceWithMixin(processed, name);
-    processed = this.appendMixinClass(processed, name);
+    // processed = this.appendMixinClass(processed, name);
   }
 
   return processed;
@@ -36,7 +36,9 @@ Transform.prototype.namePattern = function() {
 };
 
 Transform.prototype.replaceWithMixin = function(content, name) {
-  return content.replace(/@component/, '@mixin ' + name);
+  content = content.replace(/@component\(/, '@mixin ' + name + '($theme,');
+  content = content.replace(',)', ')');
+  return content;
 };
 
 Transform.prototype.appendMixinClass = function(content, name) {

--- a/lib/scss-preprocessor/broccoli-transform-components.js
+++ b/lib/scss-preprocessor/broccoli-transform-components.js
@@ -25,7 +25,7 @@ Transform.prototype.processString = function(content, relPath) {
 
   if (name) {
     processed = this.replaceWithMixin(processed, name);
-    // processed = this.appendMixinClass(processed, name);
+    processed = this.replaceThemeVariables(processed);
   }
 
   return processed;
@@ -41,15 +41,17 @@ Transform.prototype.replaceWithMixin = function(content, name) {
   return content;
 };
 
-Transform.prototype.appendMixinClass = function(content, name) {
-  var processed = content;
 
-  // ensure EOF newline
-  if (!/\n$/.test(processed)) {
-    processed += '\n';
-  }
+// Replaces:
+//
+// `^theme-variable`
+//
+// with:
+//
+// `map-get($theme, "theme-variable")`
 
-  return processed+'\n.'+name+' {\n'+'  @include '+name+'();\n}\n';
-};
+Transform.prototype.replaceThemeVariables = function(content) {
+  return content.replace(/\^([\w|-]+)(,|;|\)|\s)/gi, 'map-get($theme, "$1")$2');
+}
 
 module.exports = Transform;

--- a/lib/scss-preprocessor/index.js
+++ b/lib/scss-preprocessor/index.js
@@ -29,6 +29,8 @@ module.exports = function(tree, options) {
 
     themeTree = new ImportThemeComponents(themeTree, {
       main: themeMain,
+      themeName: theme.name,
+      themePrefix: theme.prefix,
       include: [path.join(theme.name, componentsNamespace, '*.scss')]
     });
 
@@ -60,5 +62,8 @@ module.exports = function(tree, options) {
   var scssTree = funnel(tree, { include: ['**/*.scss'] });
   scssTree = mergeTrees([scssTree].concat(themeTrees), { overwrite: true });
 
-  return scssTree;
+  var stew = require('broccoli-stew');
+  var loggedTree = stew.debug(scssTree, { name: 'derp' });
+
+  return loggedTree;
 };

--- a/lib/scss-preprocessor/index.js
+++ b/lib/scss-preprocessor/index.js
@@ -31,6 +31,7 @@ module.exports = function(tree, options) {
       main: themeMain,
       themeName: theme.name,
       themePrefix: theme.prefix,
+      parentTheme: theme.parentTheme,
       include: [path.join(theme.name, componentsNamespace, '*.scss')]
     });
 
@@ -62,8 +63,5 @@ module.exports = function(tree, options) {
   var scssTree = funnel(tree, { include: ['**/*.scss'] });
   scssTree = mergeTrees([scssTree].concat(themeTrees), { overwrite: true });
 
-  var stew = require('broccoli-stew');
-  var loggedTree = stew.debug(scssTree, { name: 'derp' });
-
-  return loggedTree;
+  return scssTree;
 };


### PR DESCRIPTION
This changes the way that our SCSS is generated.
### Component Class Generation

Generated component classes that `@include` their associated mixin are now output as part of a larger mixin that encompasses all of the styles for a particular theme. The generated theme mixins look something like the following:

``` scss
@import 'ui-base-theme';
@import "./components/tomato--ui-button--default";
@import "./components/tomato--ui-field--default";

@mixin ui-tomato-theme($theme...) {
  $theme: keywords($theme);

  // Components defined in parent theme
  &--ui-panel---content--default {
    @include base--ui-panel---content--default($theme);
  }

  &--ui-panel---titlebar--default {
    @include base--ui-panel---titlebar--default($theme);
  }

  &--ui-panel--default {
    @include base--ui-panel--default($theme);
  }

  // ...

  // Components customized in the sub theme
  &--ui-button--default {
    @include tomato--ui-button--default($theme);
  }

  &--ui-field--default {
    @include tomato--ui-field--default($theme);
  }
}
```

This means that we will end up with styles specific to this theme for every UI component, even if they weren't explicitly customized in the theme by creating a component SCSS file. This is important because, in addition to creating a component SCSS file, we want to be able to customize our themes by providing new values for the variables that control styles that apply to all of our components, such as fonts and primary colors.
### `$theme` Variables

Since themes are mixins now, we are able to stop relying on naming conventions
to emulate the variable scope that we want. We can now provide a set of
variables to our theme mixin when we `@include` it in order to customize our
theme. The arguments passed to the theme mixin are then assigned to a variable
that only exists in the scope of this mixin, which is the `$theme` variable.

`$theme` is a map that contains all of the style variables that we want to base
the rest of the theme's styles off of. The `$theme` variable is automatically
passed as the first argument to each generate `@include` statement that is
inside each of the theme's class definitions.

For example:

``` scss
&--ui-panel---titlebar--default {
  @include base--ui-panel---titlebar--default($theme);
}
```

Inside the component SCSS files we can use `map-get` to access values stored in
the `$theme` variable when defining the styles for a component:

``` scss
@component(
  $border-radius: map-get($theme, "border-radius"),
  $border-color: darken(map-get($theme, "page-background"), 15%),
  $border-size: 1px,
  $background: map-get($theme, "content-background"),
  $box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.05),
  $color: map-get($theme, "font-color")
) {
  // ...
}
```

Since `map-get($theme, "whatever")` is a mouth full, this also includes support for a `^property` shorthand, making the previous example look like:

``` scss
@component(
  $border-radius: ^border-radius,
  $border-color: darken(^page-background, 15%),
  $border-size: 1px,
  $background: ^content-background,
  $box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.05),
  $color: ^font-color
) {
  // ...
}
```

For more examples, check out https://github.com/prototypal-io/ui-base-theme/pull/13

**Since we already had our own `@component` syntax, I updated it to automatically
define `$theme` as the first argument when the actual mixin is generated.**
### Using a theme mixin

Currently the theme mixins can be used as follows:

``` scss
.tomato {
  @include ui-tomato-theme(
    $page-background: $page-background,
    $content-background: $yellow,

    $default-color: #6a6a6a,
    $error-color: #ff0000,
    $focus-color: #0090ff,
    $font-color: #867E7B,
    $primary-color: tomato,

    // ...
  );
}
```

The arguments given here are the same that end up available inside each
component mixin as `$theme`.

There's a working example at https://github.com/prototypal-io/ui-tomato-theme/pull/6
