### PR TITLE
Provide a caching strategy for AST transforms

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -64,17 +64,20 @@ var Theme = Addon.extend({
   setupHtmlTransforms: function(registry) {
     registry.add('htmlbars-ast-plugin', {
       name: 'transform-component-classes',
-      plugin: TransformComponentClasses
+      plugin: TransformComponentClasses,
+      baseDir: function() { return __dirname }
     });
 
     registry.add('htmlbars-ast-plugin', {
       name: 'transform-ui-root',
-      plugin: TransformUIRoot
+      plugin: TransformUIRoot,
+      baseDir: function() { return __dirname }
     });
 
     registry.add('htmlbars-ast-plugin', {
       name: 'transform-ui-table-components',
-      plugin: TransformUITableComponents
+      plugin: TransformUITableComponents,
+      baseDir: function() { return __dirname }
     });
   },
 


### PR DESCRIPTION
Fixes

```
DEPRECATION: ember-cli-htmlbars is opting out of caching due to an AST plugin that does not provide a caching strategy: `transform-component-classes`.
DEPRECATION: ember-cli-htmlbars is opting out of caching due to an AST plugin that does not provide a caching strategy: `transform-ui-root`.
DEPRECATION: ember-cli-htmlbars is opting out of caching due to an AST plugin that does not provide a caching strategy: `transform-ui-table-components`.
DEPRECATION: ember-cli-htmlbars is opting out of caching due to an AST plugin that does not provide a caching strategy: `flexi-attribute-c
```

See:

https://github.com/babel/broccoli-babel-transpiler/pull/89
https://github.com/ember-animation/liquid-fire/issues/485

cc @ianstarz 
