### PR TITLE
Expand component class rewriting to handle more situations

### DIFF
--- a/lib/htmlbars-plugins/transform-component-classes.js
+++ b/lib/htmlbars-plugins/transform-component-classes.js
@@ -5,92 +5,83 @@ function TransformComponentClasses(options) {
   this.options = options;
 }
 
-TransformComponentClasses.prototype = {
-  transform: function (ast) {
-    var moduleName = this.options && this.options.moduleName;
-    if (this.isComponentTemplate(moduleName)) {
-      return this.transformComponentTemplate(ast);
-    }
-    return ast;
-  },
+TransformComponentClasses.prototype.transform = function(ast) {
+  var moduleName = this.options && this.options.moduleName;
+  var traverse = this.syntax.traverse;
+  var b = this.syntax.builders;
 
-  isComponentTemplate: function (moduleName) {
-    return COMPONENT_MODULE_PATTERN.test(moduleName);
-  },
+  if (isComponentTemplate(moduleName)) {
+    traverse(ast, {
+      BlockStatement: function(node) {
+        transformClassHashPairs(node, b);
+      },
 
-  transformComponentTemplate: function (ast) {
-    var walker = new this.syntax.Walker();
-    var _this = this;
-    walker.visit(ast, function(node) {
-      if (node.type === 'ElementNode') {
-        _this.transformElementNode(node);
+      ElementNode: function(node) {
+        transformClassAttributes(node, b);
+      },
+
+      MustacheStatement: function(node) {
+        transformClassHashPairs(node, b);
+      },
+
+      SubExpression: function(node) {
+        transformClassHashPairs(node, b);
       }
     });
-    return ast;
-  },
-
-  transformElementNode: function (elementNode) {
-    var attributes = elementNode.attributes;
-
-    for (var i=0; i<attributes.length; i++) {
-      var attrNode = attributes[i];
-      if (attrNode.name === 'class') {
-        this.transformClassAttr(attrNode);
-      }
-    }
-  },
-
-  transformClassAttr: function (classAttrNode) {
-    var value = classAttrNode.value;
-    var params;
-
-    switch (value.type) {
-      case 'TextNode': // class="foo bar"
-        params = paramsFromTextNode(value);
-        break;
-      case 'ConcatStatement': // class="foo {{bar}}"
-        params = paramsFromConcatStatement(value);
-        break;
-      case 'MustacheStatement': // class={{foo}}
-        params = paramsFromMustacheStatement(value);
-        break;
-      default:
-        throw new Error('unrecognized node type "' + value.type + '" for class attribute value');
-    }
-
-    classAttrNode.value = {
-      type: 'MustacheStatement',
-      path: {
-        type: 'PathExpression',
-        original: '-ui-component-class',
-        parts: [ '-ui-component-class' ]
-      },
-      params: params,
-      hash: {
-        type: 'Hash',
-        pairs: [{
-          type: 'HashPair',
-          key: 'prefix',
-          value: {
-            type: 'PathExpression',
-            original: 'uiPrefix',
-            parts: ['uiPrefix']
-          }
-        }]
-      },
-      escaped: true
-    };
   }
+
+  return ast;
 };
 
-function makeMustacheAnExpression(mustacheStatement) {
-  if (mustacheStatement.params.length ||
-      mustacheStatement.hash.pairs.length ||
-      mustacheStatement.path.original.indexOf('-') !== -1) {
-    mustacheStatement.type = 'SubExpression';
-    return mustacheStatement;
+function transformClassAttributes(node, b) {
+  node.attributes.forEach(function(attribute) {
+    if (attribute.name === 'class') {
+      attribute.value = transformClassValue(attribute.value, b);
+    }
+  });
+}
+
+function transformClassHashPairs(node, b) {
+  node.hash.pairs.forEach(function(pair) {
+    if (pair.key === 'class') {
+      pair.value = transformClassValue(pair.value, b);
+    }
+  });
+}
+
+function transformClassValue(value, b) {
+  var params;
+
+  switch (value.type) {
+    case 'ConcatStatement': // <class="foo {{bar}}">
+      params = paramsFromConcatStatement(value);
+      break;
+    case 'MustacheStatement': // <div class={{foo}}>
+      params = paramsFromMustacheStatement(value);
+      break;
+    case 'StringLiteral': // {{input class="foo"}}
+      params = [value];
+      break;
+    case 'SubExpression': // {{input class=(concat "foo" "bar")}}
+      params = [value];
+      break;
+    case 'TextNode': // <div class="foo bar">
+      params = paramsFromTextNode(value);
+      break;
+    default:
+      throw new Error('unrecognized node type "' + value.type + '" for class attribute value');
   }
-  return mustacheStatement.path;
+
+  return b.mustache(
+    '-ui-component-class',
+    params,
+    b.hash([b.pair('prefix', b.path('uiPrefix'))]),
+    false
+  );
+};
+
+function isComponentTemplate(moduleName) {
+  return COMPONENT_MODULE_PATTERN.test(moduleName);
 }
 
 function paramsFromTextNode(textNode) {
@@ -113,6 +104,16 @@ function paramsFromConcatStatement(concatStatement) {
 function paramsFromMustacheStatement(mustacheStatement) {
   mustacheStatement.type = 'SubExpression';
   return [makeMustacheAnExpression(mustacheStatement)];
+}
+
+function makeMustacheAnExpression(mustacheStatement) {
+  if (mustacheStatement.params.length ||
+      mustacheStatement.hash.pairs.length ||
+      mustacheStatement.path.original.indexOf('-') !== -1) {
+    mustacheStatement.type = 'SubExpression';
+    return mustacheStatement;
+  }
+  return mustacheStatement.path;
 }
 
 module.exports = TransformComponentClasses;


### PR DESCRIPTION
Closes https://github.com/prototypal-io/untitled-ui/issues/107

Previously, classes were only rewritten if they were attached to an
`ElementNode`. This expands on that to also provide rewriting to classes
attached to components, blocks, and sub-expressions.

New cases covered examples:

```
{{input class="foo"}}

{{#link-to "index" class="foo"}}
  FooBar
{{/link-to}}

{{yield (hash
  foo=(component "foo" class="foo")
)}}
```
